### PR TITLE
alsadrv: added -d arg to specify alsa PCM device name

### DIFF
--- a/mt32emu_alsadrv/src/alsadrv.cpp
+++ b/mt32emu_alsadrv/src/alsadrv.cpp
@@ -103,7 +103,7 @@ int consumer_types = 0;
 snd_pcm_t *pcm_handle = NULL;
 snd_pcm_hw_params_t *pcm_hwparams;
 // char *pcm_name = "plughw:0,0";
-const char *pcm_name = "default";
+char *pcm_name = "default";
 
 
 /* midi queue control variables */

--- a/mt32emu_alsadrv/src/alsadrv.h
+++ b/mt32emu_alsadrv/src/alsadrv.h
@@ -81,6 +81,7 @@ void send_rvlevel_sysex(int newlevel);
 extern int alsa_buffer_size;
 extern char rom_path[];
 extern int eventpipe[];
+extern char *pcm_name;
 
 int init_alsadrv();
 int process_loop(int rv);

--- a/mt32emu_alsadrv/src/console.cpp
+++ b/mt32emu_alsadrv/src/console.cpp
@@ -132,6 +132,9 @@ void usage(char *argv[])
 	printf("-i msec      : Minimum (initial) buffer size in milliseconds\n");
 	
 	printf("\n");
+	printf("-d name      : ALSA PCM device name (default: \"default\") \n");
+	
+	printf("\n");
 	
 	printf("\n");
 	exit(1);
@@ -191,6 +194,11 @@ int main(int argc, char **argv)
 			break;
 		    case 'i': i++; if (i == argc) usage(argv);
 			minimum_msec = atoi(argv[i]);
+			break;
+
+		    case 'd': i++; if (i == argc) usage(argv);
+			pcm_name = (char *)malloc(strlen(argv[i]) + 1);
+			strcpy(pcm_name, argv[i]);
 			break;
 			
 		    default:

--- a/mt32emu_alsadrv/src/xmt32.cpp
+++ b/mt32emu_alsadrv/src/xmt32.cpp
@@ -465,6 +465,9 @@ void usage(char *argv[])
 	printf("-i msec      : Minimum (initial) buffer size in milliseconds\n");
 	
 	printf("\n");
+	printf("-d name      : ALSA PCM device name (default: \"default\") \n");
+
+	printf("\n");
 	exit(1);
 }
 
@@ -517,6 +520,10 @@ int main(int argc, char *argv[])
 			break;
 		    case 'i': i++; if (i == argc) usage(argv);
 			minimum_msec = atoi(argv[i]);
+			break;
+		    case 'd': i++; if (i == argc) usage(argv);
+			pcm_name = (char *)malloc(strlen(argv[i]) + 1);
+			strcpy(pcm_name, argv[i]);
 			break;
 			
 		    default:


### PR DESCRIPTION
This is so that one may specify what alsa pcm device to use instead of the hardcoded "default"
Added to both mt32d and xmt32
