### PR TITLE
Cleanup: Get rid of "using namespace".

### DIFF
--- a/mt32emu/src/AReverbModel.cpp
+++ b/mt32emu/src/AReverbModel.cpp
@@ -18,7 +18,7 @@
 #include "mt32emu.h"
 #include "AReverbModel.h"
 
-using namespace MT32Emu;
+namespace MT32Emu {
 
 // Default reverb settings for modes 0-2
 
@@ -234,4 +234,6 @@ void AReverbModel::process(const float *inLeft, const float *inRight, float *out
 		outLeft++;
 		outRight++;
 	}
+}
+
 }

--- a/mt32emu/src/DelayReverb.cpp
+++ b/mt32emu/src/DelayReverb.cpp
@@ -20,8 +20,7 @@
 #include "mt32emu.h"
 #include "DelayReverb.h"
 
-using namespace MT32Emu;
-
+namespace MT32Emu {
 
 // CONFIRMED: The values below are found via analysis of digital samples. Checked with all time and level combinations.
 // Obviously:
@@ -147,4 +146,6 @@ bool DelayReverb::isActive() const {
 		}
 	}
 	return false;
+}
+
 }

--- a/mt32emu/src/File.cpp
+++ b/mt32emu/src/File.cpp
@@ -19,7 +19,7 @@
 #include "mt32emu.h"
 #include "sha1/sha1.h"
 
-using namespace MT32Emu;
+namespace MT32Emu {
 
 static void SHA1DigestToString(char *strDigest, const unsigned int intDigest [])
 {
@@ -54,4 +54,6 @@ unsigned char* File::getSHA1() {
 	}
 	SHA1DigestToString((char *) sha1Digest, fileDigest);
 	return sha1Digest;
+}
+
 }

--- a/mt32emu/src/FileStream.cpp
+++ b/mt32emu/src/FileStream.cpp
@@ -18,8 +18,10 @@
 #include "mt32emu.h"
 #include "FileStream.h"
 
-using namespace MT32Emu;
-using namespace std;
+namespace MT32Emu {
+
+using std::ifstream;
+using std::ios_base;
 
 FileStream::FileStream() {
 	ifsp = new ifstream();
@@ -83,4 +85,6 @@ bool FileStream::open(const char *filename) {
 
 void FileStream::close() {
 	ifsp->close();
+}
+
 }

--- a/mt32emu/src/FreeverbModel.cpp
+++ b/mt32emu/src/FreeverbModel.cpp
@@ -20,7 +20,7 @@
 
 #include "freeverb/revmodel.h"
 
-using namespace MT32Emu;
+namespace MT32Emu {
 
 FreeverbModel::FreeverbModel(float useScaleTuning, float useFiltVal, float useWet, Bit8u useRoom, float useDamp) {
 	freeverb = NULL;
@@ -75,4 +75,6 @@ void FreeverbModel::setParameters(Bit8u time, Bit8u level) {
 bool FreeverbModel::isActive() const {
 	// FIXME: Not bothering to do this properly since we'll be replacing Freeverb soon...
 	return false;
+}
+
 }

--- a/mt32emu/src/Partial.cpp
+++ b/mt32emu/src/Partial.cpp
@@ -22,7 +22,7 @@
 #include "mt32emu.h"
 #include "mmath.h"
 
-using namespace MT32Emu;
+namespace MT32Emu {
 
 #ifdef INACCURATE_SMOOTH_PAN
 // Mok wanted an option for smoother panning, and we love Mok.
@@ -554,4 +554,6 @@ void Partial::startDecayAll() {
 	tva->startDecay();
 	tvp->startDecay();
 	tvf->startDecay();
+}
+
 }

--- a/mt32emu/src/PartialManager.cpp
+++ b/mt32emu/src/PartialManager.cpp
@@ -20,7 +20,7 @@
 #include "mt32emu.h"
 #include "PartialManager.h"
 
-using namespace MT32Emu;
+namespace MT32Emu {
 
 PartialManager::PartialManager(Synth *useSynth, Part **useParts) {
 	synth = useSynth;
@@ -247,4 +247,6 @@ const Partial *PartialManager::getPartial(unsigned int partialNum) const {
 		return NULL;
 	}
 	return partialTable[partialNum];
+}
+
 }

--- a/mt32emu/src/Tables.cpp
+++ b/mt32emu/src/Tables.cpp
@@ -22,7 +22,7 @@
 #include "mt32emu.h"
 #include "mmath.h"
 
-using namespace MT32Emu;
+namespace MT32Emu {
 
 Tables::Tables() {
 	initialised = false;
@@ -116,4 +116,6 @@ void Tables::init() {
 	for (int i = 0; i < 5120; i++) {
 		sinf10[i] = sin(FLOAT_PI * i / 2048.0f);
 	}
+}
+
 }


### PR DESCRIPTION
Instead of putting using namespace in all the .cpp files of mt32emu, I added an explicit namespace MT32Emu scope around the implementation.

I furthermore only included the used parts of namespace std in FileStream.cpp.

Not sure if that's how you want to treat these things though, so I'm happy to hear any feedback.
