### PR TITLE
Make all constant tables in the MT32Emu namespace static.

### DIFF
--- a/mt32emu/src/DelayReverb.cpp
+++ b/mt32emu/src/DelayReverb.cpp
@@ -27,7 +27,7 @@ namespace MT32Emu {
 // rightDelay = (leftDelay - 2) * 2 + 2
 // echoDelay = rightDelay - 1
 // Leaving these separate in case it's useful for work on other reverb modes...
-const Bit32u REVERB_TIMINGS[8][3]= {
+static const Bit32u REVERB_TIMINGS[8][3]= {
 	// {leftDelay, rightDelay, feedbackDelay}
 	{402, 802, 801},
 	{626, 1250, 1249},
@@ -39,7 +39,7 @@ const Bit32u REVERB_TIMINGS[8][3]= {
 	{8002, 16002, 16001}
 };
 
-const float REVERB_FADE[8] = {0.0f, -0.049400051f, -0.08220577f, -0.131861118f, -0.197344907f, -0.262956344f, -0.345162114f, -0.509508615f};
+static const float REVERB_FADE[8] = {0.0f, -0.049400051f, -0.08220577f, -0.131861118f, -0.197344907f, -0.262956344f, -0.345162114f, -0.509508615f};
 const float REVERB_FEEDBACK67 = -0.629960524947437f; // = -EXP2F(-2 / 3)
 const float REVERB_FEEDBACK = -0.682034520443118f; // = -EXP2F(-53 / 96)
 const float LPF_VALUE = 0.594603558f; // = EXP2F(-0.75f)

--- a/mt32emu/src/Synth.cpp
+++ b/mt32emu/src/Synth.cpp
@@ -34,7 +34,7 @@
 
 namespace MT32Emu {
 
-const ControlROMMap ControlROMMaps[7] = {
+static const ControlROMMap ControlROMMaps[7] = {
 	// ID    IDc IDbytes                     PCMmap  PCMc  tmbrA   tmbrAO, tmbrAC tmbrB   tmbrBO, tmbrBC tmbrR   trC  rhythm  rhyC  rsrv    panpot  prog    rhyMax  patMax  sysMax  timMax
 	{0x4014, 22, "\000 ver1.04 14 July 87 ", 0x3000,  128, 0x8000, 0x0000, false, 0xC000, 0x4000, false, 0x3200,  30, 0x73A6,  85,  0x57C7, 0x57E2, 0x57D0, 0x5252, 0x525E, 0x526E, 0x520A},
 	{0x4014, 22, "\000 ver1.05 06 Aug, 87 ", 0x3000,  128, 0x8000, 0x0000, false, 0xC000, 0x4000, false, 0x3200,  30, 0x7414,  85,  0x57C7, 0x57E2, 0x57D0, 0x5252, 0x525E, 0x526E, 0x520A},


### PR DESCRIPTION
As the title says it makes all the tables in the MT32Emu namespace static to avoid cluttering the namespace and give even better possibilites for optimization.
