### PR TITLE
GCC compile fixes

### DIFF
--- a/mt32emu/src/Synth.cpp
+++ b/mt32emu/src/Synth.cpp
@@ -1270,7 +1270,7 @@ void Synth::refreshSystemReverbParameters() {
 		if (isReverbEnabled()) {
 			reverbModel->open();
 		}
-#elif
+#else
 		if (isReverbEnabled()) {
 			reverbModel->mute();
 		}

--- a/mt32emu/src/Synth.h
+++ b/mt32emu/src/Synth.h
@@ -19,6 +19,7 @@
 #define MT32EMU_SYNTH_H
 
 #include <cstdarg>
+#include <cstring>
 
 namespace MT32Emu {
 


### PR DESCRIPTION
Also there were some funky undefined behavior warnings:
/home/i30817/Documents/Netbeans_projects/blah/mt32emu/src/Synth.cpp: In member function ‘void MT32Emu::Synth::produceLA32Output(MT32Emu::Sample_, MT32Emu::Bit32u)’:
/home/i30817/Documents/Netbeans_projects/blah/mt32emu/src/Synth.cpp:1487:94: warning: operation on ‘buffer’ may be undefined [-Wsequence-point]
/home/i30817/Documents/Netbeans_projects/blah/mt32emu/src/Synth.cpp:1487:94: warning: operation on ‘buffer’ may be undefined [-Wsequence-point]
/home/i30817/Documents/Netbeans_projects/blah/mt32emu/src/Synth.cpp:1487:94: warning: operation on ‘buffer’ may be undefined [-Wsequence-point]
/home/i30817/Documents/Netbeans_projects/blah/mt32emu/src/Synth.cpp:1492:51: warning: operation on ‘buffer’ may be undefined [-Wsequence-point]
/home/i30817/Documents/Netbeans_projects/blah/mt32emu/src/Synth.cpp: In member function ‘void MT32Emu::Synth::convertSamplesToOutput(MT32Emu::Sample_, MT32Emu::Bit32u, bool)’:
/home/i30817/Documents/Netbeans_projects/blah/mt32emu/src/Synth.cpp:1519:58: warning: operation on ‘buffer’ may be undefined [-Wsequence-point]

Which i don't feel competent to do anything about.
