### PR TITLE
Update the mt32emu dosbox patch to work with current svn

### DIFF
--- a/DOSBox-mt32-patch/dosbox-0.74-mt32-patch.diff
+++ b/DOSBox-mt32-patch/dosbox-0.74-mt32-patch.diff
@@ -1,17 +1,17 @@
-Index: dosbox_blah/src/Makefile.am
+Index: dosbox-0.74/src/Makefile.am
 ===================================================================
---- dosbox_blah.orig/src/Makefile.am	2014-01-18 11:38:01.588528167 +0000
-+++ dosbox_blah/src/Makefile.am	2014-01-18 11:38:01.520527830 +0000
+--- dosbox-0.74.orig/src/Makefile.am	2014-01-18 11:38:01.588528167 +0000
++++ dosbox-0.74/src/Makefile.am	2014-01-18 11:38:01.520527830 +0000
 @@ -17,4 +17,4 @@
  
  EXTRA_DIST = winres.rc dosbox.ico
  
 -
 +LIBS +=  -lmt32emu
-Index: dosbox_blah/src/dosbox.cpp
+Index: dosbox-0.74/src/dosbox.cpp
 ===================================================================
---- dosbox_blah.orig/src/dosbox.cpp	2014-01-18 11:38:01.588528167 +0000
-+++ dosbox_blah/src/dosbox.cpp	2014-01-18 11:41:22.573524798 +0000
+--- dosbox-0.74.orig/src/dosbox.cpp	2014-01-18 11:38:01.588528167 +0000
++++ dosbox-0.74/src/dosbox.cpp	2014-01-18 11:41:22.573524798 +0000
 @@ -483,7 +483,7 @@
  	
  	const char* mputypes[] = { "intelligent", "uart", "none",0};
@@ -90,10 +90,10 @@ Index: dosbox_blah/src/dosbox.cpp
  #if C_DEBUG
  	secprop=control->AddSection_prop("debug",&DEBUG_Init);
  #endif
-Index: dosbox_blah/src/gui/Makefile.am
+Index: dosbox-0.74/src/gui/Makefile.am
 ===================================================================
---- dosbox_blah.orig/src/gui/Makefile.am	2014-01-18 11:38:01.588528167 +0000
-+++ dosbox_blah/src/gui/Makefile.am	2014-01-18 11:38:01.580528127 +0000
+--- dosbox-0.74.orig/src/gui/Makefile.am	2014-01-18 11:38:01.588528167 +0000
++++ dosbox-0.74/src/gui/Makefile.am	2014-01-18 11:38:01.580528127 +0000
 @@ -7,5 +7,5 @@
  	render_templates_sai.h render_templates_hq.h \
  	render_templates_hq2x.h render_templates_hq3x.h \
@@ -101,10 +101,10 @@ Index: dosbox_blah/src/gui/Makefile.am
 -	midi_coremidi.h sdl_gui.cpp dosbox_splash.h
 +	midi_coremidi.h midi_mt32.h sdl_gui.cpp dosbox_splash.h
  
-Index: dosbox_blah/src/gui/midi.cpp
+Index: dosbox-0.74/src/gui/midi.cpp
 ===================================================================
---- dosbox_blah.orig/src/gui/midi.cpp	2014-01-18 11:38:01.588528167 +0000
-+++ dosbox_blah/src/gui/midi.cpp	2014-01-18 11:38:01.580528127 +0000
+--- dosbox-0.74.orig/src/gui/midi.cpp	2014-01-18 11:38:01.588528167 +0000
++++ dosbox-0.74/src/gui/midi.cpp	2014-01-18 11:38:01.580528127 +0000
 @@ -91,6 +91,8 @@
  
  #endif
@@ -114,10 +114,10 @@ Index: dosbox_blah/src/gui/midi.cpp
  DB_Midi midi;
  
  void MIDI_RawOutByte(Bit8u data) {
-Index: dosbox_blah/src/gui/midi_mt32.h
+Index: dosbox-0.74/src/gui/midi_mt32.h
 ===================================================================
 --- /dev/null	1970-01-01 00:00:00.000000000 +0000
-+++ dosbox_blah/src/gui/midi_mt32.h	2014-01-18 11:40:51.585371136 +0000
++++ dosbox-0.74/src/gui/midi_mt32.h	2014-01-18 11:40:51.585371136 +0000
 @@ -0,0 +1,249 @@
 +#include <mt32emu/mt32emu.h>
 +#include <SDL_thread.h>


### PR DESCRIPTION
I don't know if you want to keep it working with the source as of the time of the release or with the current one. I'm using the current one so it would be convenient for me, but if you prefer, just give it a new name on your repository (or don't merge at all).
