### PR TITLE
ALSADriver: Advertise as `MIDI_GENERIC` as well as MT32

### DIFF
--- a/mt32emu_qt/src/mididrv/ALSADriver.cpp
+++ b/mt32emu_qt/src/mididrv/ALSADriver.cpp
@@ -256,6 +256,7 @@ int ALSAMidiDriver::alsa_setup_midi() {
 	seqPort = snd_seq_create_simple_port(snd_seq, "Standard",
 						SND_SEQ_PORT_CAP_SUBS_WRITE |
 						SND_SEQ_PORT_CAP_WRITE,
+						SND_SEQ_PORT_TYPE_MIDI_GENERIC |
 						SND_SEQ_PORT_TYPE_MIDI_MT32 |
 						SND_SEQ_PORT_TYPE_SYNTH);
 	if (seqPort < 0) {


### PR DESCRIPTION
Some programs, such as the virtual piano [VMPK](http://vmpk.sourceforge.net/) show only midi outputs with `SND_SEQ_PORT_TYPE_MIDI_GENERIC`.

The [alsa documentation](http://www.alsa-project.org/alsa-doc/alsa-lib/group___seq_port.html) for `SND_SEQ_PORT_TYPE_MIDI_GENERIC` says "This port understands MIDI messages." It does not mean General Midi.

So this seems to imply that a MT32 synth has to advertise both as `MIDI_GENERIC` and as `MIDI_MT32`.
