### PR TITLE
Remove incorrect NULL checks.

### DIFF
--- a/mt32emu/src/Synth.cpp
+++ b/mt32emu/src/Synth.cpp
@@ -235,7 +235,6 @@ bool Synth::isReversedStereoEnabled() {
 }
 
 bool Synth::loadControlROM(const ROMImage &controlROMImage) {
-	if (&controlROMImage == NULL) return false;
 	File *file = controlROMImage.getFile();
 	const ROMInfo *controlROMInfo = controlROMImage.getROMInfo();
 	if ((controlROMInfo == NULL)
@@ -272,7 +271,6 @@ bool Synth::loadControlROM(const ROMImage &controlROMImage) {
 }
 
 bool Synth::loadPCMROM(const ROMImage &pcmROMImage) {
-	if (&pcmROMImage == NULL) return false;
 	File *file = pcmROMImage.getFile();
 	const ROMInfo *pcmROMInfo = pcmROMImage.getROMInfo();
 	if ((pcmROMInfo == NULL)


### PR DESCRIPTION
In well-defined C++ code references can never be bound to dereferenced NULL
pointers. Thus, compilers can assume that the address a reference points at is
always non-NULL. The reason is that if this happens, the behavior is undefined
from now on. Thus, the compiler can do as it pleases. As a result, compilers
might simply remove checks like the ones removed here.

clang's "-Wtautological-undefined-compare" warning option can be used to spot
such issues.

There might be a greater issue in the underlying code design here. Thus, now some supposedly important check might be missing even if the compiler decides not to remove it. So, it's probably best to see whether further changes should be made to adjust for this.
