### PR TITLE
Comment out unused variable floatKeyfollow.

### DIFF
--- a/mt32emu/src/Part.cpp
+++ b/mt32emu/src/Part.cpp
@@ -33,13 +33,14 @@ static const Bit8u PartialMixStruct[13] = {
 	1, 3, 3, 2, 2, 2, 2
 };
 
+#if 0
 static const float floatKeyfollow[17] = {
 	-1.0f, -1.0f / 2.0f, -1.0f / 4.0f, 0.0f,
 	1.0f / 8.0f, 1.0f / 4.0f, 3.0f / 8.0f, 1.0f / 2.0f, 5.0f / 8.0f, 3.0f / 4.0f, 7.0f / 8.0f, 1.0f,
 	5.0f / 4.0f, 3.0f / 2.0f, 2.0f,
 	1.0009765625f, 1.0048828125f
 };
-
+#endif
 
 RhythmPart::RhythmPart(Synth *useSynth, unsigned int usePartNum): Part(useSynth, usePartNum) {
 	strcpy(name, "Rhythm");


### PR DESCRIPTION
I am not sure if it's going to be used in the future. For now, I simply put it inside an #if 0 block to silence some warnings about it.
