### PR TITLE
Do not rely on global constructors.

### DIFF
--- a/mt32emu/src/ROMInfo.cpp
+++ b/mt32emu/src/ROMInfo.cpp
@@ -20,8 +20,8 @@
 
 namespace MT32Emu {
 
-static const ControlROMFeatureSet MT32_COMPATIBLE(true);
-static const ControlROMFeatureSet CM32L_COMPATIBLE(false);
+static const ControlROMFeatureSet MT32_COMPATIBLE = { true };
+static const ControlROMFeatureSet CM32L_COMPATIBLE = { false };
 
 // Known ROMs
 static const ROMInfo CTRL_MT32_V1_04 = {65536, "5a5cb5a77d7d55ee69657c2f870416daed52dea7", ROMInfo::Control, "ctrl_mt32_1_04", "MT-32 Control v1.04", ROMInfo::Full, NULL, &MT32_COMPATIBLE};
@@ -107,9 +107,6 @@ File* ROMImage::getFile() const {
 
 const ROMInfo* ROMImage::getROMInfo() const {
 	return romInfo;
-}
-
-ControlROMFeatureSet::ControlROMFeatureSet(bool useDefaultReverbMT32Compatible) : defaultReverbMT32Compatible(useDefaultReverbMT32Compatible) {
 }
 
 bool ControlROMFeatureSet::isDefaultReverbMT32Compatible() const {

--- a/mt32emu/src/ROMInfo.h
+++ b/mt32emu/src/ROMInfo.h
@@ -75,11 +75,8 @@ public:
 };
 
 struct ControlROMFeatureSet {
-private:
 	unsigned int defaultReverbMT32Compatible : 1;
 
-public:
-	ControlROMFeatureSet(bool defaultReverbMT32Compatible);
 	bool isDefaultReverbMT32Compatible() const;
 };
 


### PR DESCRIPTION
This makes sure that no global constructors are required to run in the main
MUNT code. Global constructors have an implementation specific execution
order/time. There are only some minimal guarantees by the C++ standard.

In ScummVM these can be an issue for some obscure platforms because they might
not even get executed at all. This is not standard conforming but the reason
we disallow code with global constructors.

The change is not exactly pretty since it removes the visibility control of
ControlROMFeatureSet. I am not sure whether this data type is going to be
extended in the future or not. If it isn't, it might be possible to just
replace it directly with a boolean value.

clang's -Wglobal-constructors warning option allows to check whether global
constructors are used.

This change is really mainly motivated by our coding rules in ScummVM. There shouldn't be any issue for platforms with standard compliant construction since all uses of it are in the same translation code as the functions accessing it. Thus, it might be that you simply not care about it. In this case we will make a similar change local to our copy of MUNT. Any thoughts are welcome though.
