### PR TITLE
Handle continuation of large sysexes split by ALSA

### DIFF
--- a/mt32emu_qt/src/mididrv/ALSADriver.h
+++ b/mt32emu_qt/src/mididrv/ALSADriver.h
@@ -2,6 +2,7 @@
 #define ALSA_MIDI_DRIVER_H
 
 #include <alsa/asoundlib.h>
+#include <QVector>
 
 #include "MidiDriver.h"
 
@@ -23,6 +24,7 @@ private:
 	pthread_t processingThreadID;
 	volatile bool stopProcessing;
 	QList<unsigned int> clients;
+	QVector<MT32Emu::Bit8u> sysexBuf;
 
 	static void *processingThread(void *userData);
 	int alsa_setup_midi();


### PR DESCRIPTION
ALSA's rawmidi "virtual" plugin enforces a hardcoded limit of 256 bytes
per generated sequencer event.  The PS/1 version of Silpheed includes a
MT32.DRV which sends a SysEx message that is 264 bytes long, which is
broken into two consecutive incomplete SND_SEQ_EVENT_SYSEX sequencer
event segments.  We have to reassemble the segments for the MT-32 to be
initialized correctly.

Before this workaround, a user reported incorrect instruments with this
particular version of Silpheed, when using mt32emu-qt through DOSEMU's
ALSA rawmidi interface.

This workaround should also be applicable to the old mt32_alsadrv as it
uses the same interface.