### PR TITLE
Use sign qualifiers for 'char' based variables in more places.

### DIFF
--- a/mt32emu/src/Structures.h
+++ b/mt32emu/src/Structures.h
@@ -235,7 +235,7 @@ struct PatchCache {
 	bool playPartial;
 	bool PCMPartial;
 	int pcm;
-	char waveform;
+	Bit8u waveform;
 
 	Bit32u structureMix;
 	int structurePosition;

--- a/mt32emu/src/Synth.cpp
+++ b/mt32emu/src/Synth.cpp
@@ -843,7 +843,7 @@ void Synth::playMsgNow(Bit32u msg) {
 
 	//printDebug("Playing chan %d, code 0x%01x note: 0x%02x", chan, code, note);
 
-	char part = chantable[chan];
+	Bit8s part = chantable[chan];
 	if (part < 0 || part > 8) {
 #if MT32EMU_MONITOR_MIDI > 0
 		printDebug("Play msg on unreg chan %d (%d): code=0x%01x, vel=%d", chan, part, code, velocity);


### PR DESCRIPTION
This makes the use of types for 'char' based variables a bit more consistent. It also silences a warning on systems where 'char' is unsigned by default.