### PR TITLE
New Synth member function for querying whether the MIDI event queue is empty

### DIFF
--- a/mt32emu/src/MidiEventQueue.h
+++ b/mt32emu/src/MidiEventQueue.h
@@ -63,6 +63,7 @@ public:
 	const MidiEvent *peekMidiEvent();
 	void dropMidiEvent();
 	bool isFull() const;
+	bool isEmpty() const;
 };
 
 } // namespace MT32Emu

--- a/mt32emu/src/Synth.cpp
+++ b/mt32emu/src/Synth.cpp
@@ -742,6 +742,10 @@ bool Synth::isOpen() const {
 	return opened;
 }
 
+bool Synth::queueIsEmpty() const {
+	return midiQueue == NULL || midiQueue->isEmpty();
+}
+
 void Synth::flushMIDIQueue() {
 	if (midiQueue != NULL) {
 		for (;;) {
@@ -1649,6 +1653,10 @@ void MidiEventQueue::dropMidiEvent() {
 
 bool MidiEventQueue::isFull() const {
 	return startPosition == ((endPosition + 1) & ringBufferMask);
+}
+
+bool MidiEventQueue::isEmpty() const {
+	return startPosition == endPosition;
 }
 
 Bit32u Synth::getStereoOutputSampleRate() const {

--- a/mt32emu/src/Synth.h
+++ b/mt32emu/src/Synth.h
@@ -275,6 +275,9 @@ public:
 	// Returns true if the synth is in completely initialized state, otherwise returns false.
 	MT32EMU_EXPORT bool isOpen() const;
 
+	// Returns true if the internal MIDI event queue is empty, otherwise returns false.
+	MT32EMU_EXPORT bool queueIsEmpty() const;
+
 	// All the enqueued events are processed by the synth immediately.
 	MT32EMU_EXPORT void flushMIDIQueue();
 


### PR DESCRIPTION
This allows for easy detection of "end of track" situations when playing MIDI files, since now we can do:

    if (synth->queueIsEmpty() and not synth->isActive()) {
        // Nothing more to render.
    }