### PR TITLE
- Don't return false in Synth::isActive() if there's more events to render

### DIFF
--- a/mt32emu/src/MidiEventQueue.h
+++ b/mt32emu/src/MidiEventQueue.h
@@ -63,6 +63,7 @@ public:
 	const MidiEvent *peekMidiEvent();
 	void dropMidiEvent();
 	bool isFull() const;
+	bool isEmpty() const;
 };
 
 } // namespace MT32Emu

--- a/mt32emu/src/Synth.cpp
+++ b/mt32emu/src/Synth.cpp
@@ -1651,6 +1651,10 @@ bool MidiEventQueue::isFull() const {
 	return startPosition == ((endPosition + 1) & ringBufferMask);
 }
 
+bool MidiEventQueue::isEmpty() const {
+	return startPosition == endPosition;
+}
+
 Bit32u Synth::getStereoOutputSampleRate() const {
 	return (analog == NULL) ? SAMPLE_RATE : analog->getOutputSampleRate();
 }
@@ -1910,7 +1914,7 @@ bool Synth::isAbortingPoly() const {
 }
 
 bool Synth::isActive() const {
-	if (hasActivePartials()) {
+	if (hasActivePartials() || (midiQueue != NULL && !midiQueue->isEmpty())) {
 		return true;
 	}
 	if (isReverbEnabled()) {


### PR DESCRIPTION
Synth::isActive() now checks whether there's more events in the MIDI queue that need to be rendered.