### PR TITLE
Remove use of non-ASCII characters in source files.

### DIFF
--- a/mt32emu/src/Enumerations.h
+++ b/mt32emu/src/Enumerations.h
@@ -1,4 +1,4 @@
-﻿/* Copyright (C) 2003, 2004, 2005, 2006, 2008, 2009 Dean Beeler, Jerome Fisher
+/* Copyright (C) 2003, 2004, 2005, 2006, 2008, 2009 Dean Beeler, Jerome Fisher
  * Copyright (C) 2011-2016 Dean Beeler, Jerome Fisher, Sergey V. Mikayev
  *
  *  This program is free software: you can redistribute it and/or modify

--- a/mt32emu/src/LA32FloatWaveGenerator.h
+++ b/mt32emu/src/LA32FloatWaveGenerator.h
@@ -24,7 +24,7 @@ namespace MT32Emu {
 /**
  * LA32WaveGenerator is aimed to represent the exact model of LA32 wave generator.
  * The output square wave is created by adding high / low linear segments in-between
- * the rising and falling cosine segments. Basically, it’s very similar to the phase distortion synthesis.
+ * the rising and falling cosine segments. Basically, it's very similar to the phase distortion synthesis.
  * Behaviour of a true resonance filter is emulated by adding decaying sine wave.
  * The beginning and the ending of the resonant sine is multiplied by a cosine window.
  * To synthesise sawtooth waves, the resulting square wave is multiplied by synchronous cosine wave.

--- a/mt32emu/src/LA32WaveGenerator.h
+++ b/mt32emu/src/LA32WaveGenerator.h
@@ -59,7 +59,7 @@ public:
 /**
  * LA32WaveGenerator is aimed to represent the exact model of LA32 wave generator.
  * The output square wave is created by adding high / low linear segments in-between
- * the rising and falling cosine segments. Basically, it’s very similar to the phase distortion synthesis.
+ * the rising and falling cosine segments. Basically, it's very similar to the phase distortion synthesis.
  * Behaviour of a true resonance filter is emulated by adding decaying sine wave.
  * The beginning and the ending of the resonant sine is multiplied by a cosine window.
  * To synthesise sawtooth waves, the resulting square wave is multiplied by synchronous cosine wave.


### PR DESCRIPTION
This is pretty self explanatory: I removed a BOM marker from "Enumerations.h", making the file ASCII again. And I used `'` for apostrophe in two files instead of some other (non-ASCII, non-UTF8) encoding of appareantly an apostrophe.