### PR TITLE
Eliminating warnings

### DIFF
--- a/mt32emu/src/Analog.cpp
+++ b/mt32emu/src/Analog.cpp
@@ -182,8 +182,8 @@ void Analog::process(Sample *outStream, const Sample *nonReverbLeft, const Sampl
 			outSampleL = leftChannelLPF.process(0);
 			outSampleR = rightChannelLPF.process(0);
 		} else {
-			SampleEx inSampleL = ((SampleEx)*(nonReverbLeft++) + (SampleEx)*(reverbDryLeft++)) * synthGain + (SampleEx)*(reverbWetLeft++) * reverbGain;
-			SampleEx inSampleR = ((SampleEx)*(nonReverbRight++) + (SampleEx)*(reverbDryRight++)) * synthGain + (SampleEx)*(reverbWetRight++) * reverbGain;
+			SampleEx inSampleL = (SampleEx(*(nonReverbLeft++)) + SampleEx(*(reverbDryLeft++))) * synthGain + SampleEx(*(reverbWetLeft++)) * reverbGain;
+			SampleEx inSampleR = (SampleEx(*(nonReverbRight++)) + SampleEx(*(reverbDryRight++))) * synthGain + SampleEx(*(reverbWetRight++)) * reverbGain;
 
 #if !MT32EMU_USE_FLOAT_SAMPLES
 			inSampleL >>= OUTPUT_GAIN_FRACTION_BITS;

--- a/mt32emu/src/BReverbModel.cpp
+++ b/mt32emu/src/BReverbModel.cpp
@@ -192,7 +192,7 @@ static Sample weirdMul(Sample a, Bit8u addMask, Bit8u carryMask) {
 	}
 	return res;
 #else
-	return Sample(((Bit32s)a * addMask) >> 8);
+	return Sample((Bit32s(a) * addMask) >> 8);
 #endif
 }
 
@@ -504,9 +504,9 @@ void BReverbModel::process(const Sample *inLeft, const Sample *inRight, Sample *
 				 *   Analysing of the algorithm suggests that the overflow is most probable when the combs output is added below.
 				 *   So, despite this isn't actually accurate, we only add the check here for performance reasons.
 				 */
-				Sample outSample = Synth::clipSampleEx(Synth::clipSampleEx(Synth::clipSampleEx(Synth::clipSampleEx((SampleEx)outL1 + SampleEx(outL1 >> 1)) + (SampleEx)outL2) + SampleEx(outL2 >> 1)) + (SampleEx)outL3);
+				Sample outSample = Synth::clipSampleEx(Synth::clipSampleEx(Synth::clipSampleEx(Synth::clipSampleEx(SampleEx(outL1) + (outL1 >> 1)) + SampleEx(outL2)) + (outL2 >> 1)) + SampleEx(outL3));
 #else
-				Sample outSample = Synth::clipSampleEx((SampleEx)outL1 + SampleEx(outL1 >> 1) + (SampleEx)outL2 + SampleEx(outL2 >> 1) + (SampleEx)outL3);
+				Sample outSample = Synth::clipSampleEx(SampleEx(outL1) + (outL1 >> 1) + SampleEx(outL2) + (outL2 >> 1) + SampleEx(outL3));
 #endif
 				*(outLeft++) = weirdMul(outSample, wetLevel, 0xFF);
 			}
@@ -518,9 +518,9 @@ void BReverbModel::process(const Sample *inLeft, const Sample *inRight, Sample *
 				Sample outSample = 1.5f * (outR1 + outR2) + outR3;
 #elif MT32EMU_BOSS_REVERB_PRECISE_MODE
 				// See the note above for the left channel output.
-				Sample outSample = Synth::clipSampleEx(Synth::clipSampleEx(Synth::clipSampleEx(Synth::clipSampleEx((SampleEx)outR1 + SampleEx(outR1 >> 1)) + (SampleEx)outR2) + SampleEx(outR2 >> 1)) + (SampleEx)outR3);
+				Sample outSample = Synth::clipSampleEx(Synth::clipSampleEx(Synth::clipSampleEx(Synth::clipSampleEx(SampleEx(outR1) + (outR1 >> 1)) + SampleEx(outR2)) + (outR2 >> 1)) + SampleEx(outR3));
 #else
-				Sample outSample = Synth::clipSampleEx((SampleEx)outR1 + SampleEx(outR1 >> 1) + (SampleEx)outR2 + SampleEx(outR2 >> 1) + (SampleEx)outR3);
+				Sample outSample = Synth::clipSampleEx(SampleEx(outR1) + (outR1 >> 1) + SampleEx(outR2) + (outR2 >> 1) + SampleEx(outR3));
 #endif
 				*(outRight++) = weirdMul(outSample, wetLevel, 0xFF);
 			}

--- a/mt32emu/src/File.cpp
+++ b/mt32emu/src/File.cpp
@@ -51,7 +51,7 @@ const File::SHA1Digest &AbstractFile::getSHA1() {
 
 	unsigned char fileDigest[20];
 
-	sha1::calc(data, (int)size, fileDigest);
+	sha1::calc(data, int(size), fileDigest);
 	sha1::toHexString(fileDigest, sha1Digest);
 	return sha1Digest;
 }

--- a/mt32emu/src/FileStream.cpp
+++ b/mt32emu/src/FileStream.cpp
@@ -40,7 +40,7 @@ size_t FileStream::getSize() {
 		return 0;
 	}
 	ifsp.seekg(0, ios_base::end);
-	size = (size_t)ifsp.tellg();
+	size = size_t(ifsp.tellg());
 	return size;
 }
 
@@ -59,8 +59,8 @@ const Bit8u *FileStream::getData() {
 		return NULL;
 	}
 	ifsp.seekg(0);
-	ifsp.read((char *)fileData, (std::streamsize)size);
-	if ((size_t)ifsp.tellg() != size) {
+	ifsp.read(reinterpret_cast<char *>(fileData), std::streamsize(size));
+	if (size_t(ifsp.tellg()) != size) {
 		delete[] fileData;
 		return NULL;
 	}

--- a/mt32emu/src/LA32WaveGenerator.h
+++ b/mt32emu/src/LA32WaveGenerator.h
@@ -147,12 +147,13 @@ class LA32WaveGenerator {
 	} phase;
 
 	// Current phase of the resonance wave
-	enum {
+	enum ResonantPhase_t {
 		POSITIVE_RISING_RESONANCE_SINE_SEGMENT,
 		POSITIVE_FALLING_RESONANCE_SINE_SEGMENT,
 		NEGATIVE_FALLING_RESONANCE_SINE_SEGMENT,
 		NEGATIVE_RISING_RESONANCE_SINE_SEGMENT
-	} resonancePhase;
+	};
+	ResonantPhase_t resonancePhase;
 
 	// Resulting log-space samples of the square and resonance waves
 	LogSample squareLogSample;

--- a/mt32emu/src/MidiStreamParser.cpp
+++ b/mt32emu/src/MidiStreamParser.cpp
@@ -73,7 +73,7 @@ MidiStreamParser::MidiStreamParser(Bit32u initialStreamBufferCapacity) :
 MidiStreamParserImpl::MidiStreamParserImpl(MidiReceiver &useReceiver, MidiReporter &useReporter, Bit32u initialStreamBufferCapacity) :
 	midiReceiver(useReceiver), midiReporter(useReporter)
 {
-	if (initialStreamBufferCapacity < (Bit32u)SYSEX_BUFFER_SIZE) initialStreamBufferCapacity = SYSEX_BUFFER_SIZE;
+	if (initialStreamBufferCapacity < Bit32u(SYSEX_BUFFER_SIZE)) initialStreamBufferCapacity = SYSEX_BUFFER_SIZE;
 	if (MAX_STREAM_BUFFER_SIZE < initialStreamBufferCapacity) initialStreamBufferCapacity = MAX_STREAM_BUFFER_SIZE;
 	streamBufferCapacity = initialStreamBufferCapacity;
 	streamBuffer = new Bit8u[streamBufferCapacity];
@@ -119,7 +119,7 @@ void MidiStreamParserImpl::parseStream(const Bit8u *stream, Bit32u length) {
 
 void MidiStreamParserImpl::processShortMessage(const Bit32u message) {
 	// Adds running status to the MIDI message if it doesn't contain one
-	Bit8u status = (Bit8u)message;
+	Bit8u status = Bit8u(message);
 	if (0xF8 <= status) {
 		midiReceiver.handleSystemRealtimeMessage(status);
 	} else if (processStatusByte(status)) {

--- a/mt32emu/src/Part.cpp
+++ b/mt32emu/src/Part.cpp
@@ -116,7 +116,7 @@ Bit32s Part::getPitchBend() const {
 
 void Part::setBend(unsigned int midiBend) {
 	// CONFIRMED:
-	pitchBend = (((signed)midiBend - 8192) * pitchBenderRange) >> 14; // PORTABILITY NOTE: Assumes arithmetic shift
+	pitchBend = ((static_cast<signed>(midiBend) - 8192) * pitchBenderRange) >> 14; // PORTABILITY NOTE: Assumes arithmetic shift
 }
 
 Bit8u Part::getModulation() const {
@@ -124,7 +124,7 @@ Bit8u Part::getModulation() const {
 }
 
 void Part::setModulation(unsigned int midiModulation) {
-	modulation = (Bit8u)midiModulation;
+	modulation = Bit8u(midiModulation);
 }
 
 void Part::resetAllControllers() {
@@ -259,26 +259,26 @@ void Part::cacheTimbre(PatchCache cache[4], const TimbreParam *timbre) {
 
 		switch (t) {
 		case 0:
-			cache[t].PCMPartial = (PartialStruct[(int)timbre->common.partialStructure12] & 0x2) ? true : false;
-			cache[t].structureMix = PartialMixStruct[(int)timbre->common.partialStructure12];
+			cache[t].PCMPartial = (PartialStruct[int(timbre->common.partialStructure12)] & 0x2) ? true : false;
+			cache[t].structureMix = PartialMixStruct[int(timbre->common.partialStructure12)];
 			cache[t].structurePosition = 0;
 			cache[t].structurePair = 1;
 			break;
 		case 1:
-			cache[t].PCMPartial = (PartialStruct[(int)timbre->common.partialStructure12] & 0x1) ? true : false;
-			cache[t].structureMix = PartialMixStruct[(int)timbre->common.partialStructure12];
+			cache[t].PCMPartial = (PartialStruct[int(timbre->common.partialStructure12)] & 0x1) ? true : false;
+			cache[t].structureMix = PartialMixStruct[int(timbre->common.partialStructure12)];
 			cache[t].structurePosition = 1;
 			cache[t].structurePair = 0;
 			break;
 		case 2:
-			cache[t].PCMPartial = (PartialStruct[(int)timbre->common.partialStructure34] & 0x2) ? true : false;
-			cache[t].structureMix = PartialMixStruct[(int)timbre->common.partialStructure34];
+			cache[t].PCMPartial = (PartialStruct[int(timbre->common.partialStructure34)] & 0x2) ? true : false;
+			cache[t].structureMix = PartialMixStruct[int(timbre->common.partialStructure34)];
 			cache[t].structurePosition = 0;
 			cache[t].structurePair = 3;
 			break;
 		case 3:
-			cache[t].PCMPartial = (PartialStruct[(int)timbre->common.partialStructure34] & 0x1) ? true : false;
-			cache[t].structureMix = PartialMixStruct[(int)timbre->common.partialStructure34];
+			cache[t].PCMPartial = (PartialStruct[int(timbre->common.partialStructure34)] & 0x1) ? true : false;
+			cache[t].structureMix = PartialMixStruct[int(timbre->common.partialStructure34)];
 			cache[t].structurePosition = 1;
 			cache[t].structurePair = 2;
 			break;
@@ -312,7 +312,7 @@ const char *Part::getName() const {
 
 void Part::setVolume(unsigned int midiVolume) {
 	// CONFIRMED: This calculation matches the table used in the control ROM
-	patchTemp->outputLevel = (Bit8u)(midiVolume * 100 / 127);
+	patchTemp->outputLevel = Bit8u((midiVolume * 100 / 127));
 	//synth->printDebug("%s (%s): Set volume to %d", name, currentInstr, midiVolume);
 }
 
@@ -326,7 +326,7 @@ Bit8u Part::getExpression() const {
 
 void Part::setExpression(unsigned int midiExpression) {
 	// CONFIRMED: This calculation matches the table used in the control ROM
-	expression = (Bit8u)(midiExpression * 100 / 127);
+	expression = Bit8u((midiExpression * 100 / 127));
 }
 
 void RhythmPart::setPan(unsigned int midiPan) {
@@ -341,9 +341,9 @@ void Part::setPan(unsigned int midiPan) {
 	// NOTE: Panning is inverted compared to GM.
 
 	// CM-32L: Divide by 8.5
-	patchTemp->panpot = (Bit8u)((midiPan << 3) / 68);
+	patchTemp->panpot = Bit8u(((midiPan << 3) / 68));
 	// FIXME: MT-32: Divide by 9
-	//patchTemp->panpot = (Bit8u)(midiPan / 9);
+	//patchTemp->panpot = Bit8u((midiPan / 9));
 
 	//synth->printDebug("%s (%s): Set pan to %d", name, currentInstr, panpot);
 }
@@ -511,7 +511,7 @@ void Part::playPoly(const PatchCache cache[4], const MemParams::RhythmTemp *rhyt
 #if MT32EMU_MONITOR_PARTIALS > 1
 	synth->printPartialUsage();
 #endif
-	synth->reportHandler->onPolyStateChanged((Bit8u)partNum);
+	synth->reportHandler->onPolyStateChanged(Bit8u(partNum));
 }
 
 void Part::allNotesOff() {
@@ -597,7 +597,7 @@ void Part::partialDeactivated(Poly *poly) {
 	if (!poly->isActive()) {
 		activePolys.remove(poly);
 		synth->partialManager->polyFreed(poly);
-		synth->reportHandler->onPolyStateChanged((Bit8u)partNum);
+		synth->reportHandler->onPolyStateChanged(Bit8u(partNum));
 	}
 }
 

--- a/mt32emu/src/Partial.cpp
+++ b/mt32emu/src/Partial.cpp
@@ -318,8 +318,8 @@ bool Partial::produceOutput(Sample *leftBuf, Sample *rightBuf, Bit32u length) {
 		// Though, it is unknown whether this overflow is exploited somewhere.
 		Sample leftOut = Sample((sample * leftPanValue) >> 8);
 		Sample rightOut = Sample((sample * rightPanValue) >> 8);
-		*leftBuf = Synth::clipSampleEx((SampleEx)*leftBuf + (SampleEx)leftOut);
-		*rightBuf = Synth::clipSampleEx((SampleEx)*rightBuf + (SampleEx)rightOut);
+		*leftBuf = Synth::clipSampleEx(SampleEx(*leftBuf) + SampleEx(leftOut));
+		*rightBuf = Synth::clipSampleEx(SampleEx(*rightBuf) + SampleEx(rightOut));
 		leftBuf++;
 		rightBuf++;
 #endif

--- a/mt32emu/src/TVF.cpp
+++ b/mt32emu/src/TVF.cpp
@@ -62,7 +62,7 @@ static int calcBaseCutoff(const TimbreParam::PartialParam *partialParam, Bit32u 
 	static const Bit8s keyfollowMult21[] = {-21, -10, -5, 0, 2, 5, 8, 10, 13, 16, 18, 21, 26, 32, 42, 21, 21};
 	int baseCutoff = keyfollowMult21[partialParam->tvf.keyfollow] - keyfollowMult21[partialParam->wg.pitchKeyfollow];
 	// baseCutoff range now: -63 to 63
-	baseCutoff *= (int)key - 60;
+	baseCutoff *= int(key) - 60;
 	// baseCutoff range now: -3024 to 3024
 	int biasPoint = partialParam->tvf.biasPoint;
 	if ((biasPoint & 0x40) == 0) {
@@ -98,7 +98,7 @@ static int calcBaseCutoff(const TimbreParam::PartialParam *partialParam, Bit32u 
 	if (baseCutoff > 255) {
 		baseCutoff = 255;
 	}
-	return (Bit8u)baseCutoff;
+	return Bit8u(baseCutoff);
 }
 
 TVF::TVF(const Partial *usePartial, LA32Ramp *useCutoffModifierRamp) :
@@ -130,7 +130,7 @@ void TVF::reset(const TimbreParam::PartialParam *newPartialParam, unsigned int b
 	int newLevelMult = velocity * newPartialParam->tvf.envVeloSensitivity;
 	newLevelMult >>= 6;
 	newLevelMult += 109 - newPartialParam->tvf.envVeloSensitivity;
-	newLevelMult += ((signed)key - 60) >> (4 - newPartialParam->tvf.envDepthKeyfollow);
+	newLevelMult += (signed(key) - 60) >> (4 - newPartialParam->tvf.envDepthKeyfollow);
 	if (newLevelMult < 0) {
 		newLevelMult = 0;
 	}
@@ -142,7 +142,7 @@ void TVF::reset(const TimbreParam::PartialParam *newPartialParam, unsigned int b
 	levelMult = newLevelMult;
 
 	if (newPartialParam->tvf.envTimeKeyfollow != 0) {
-		keyTimeSubtraction = ((signed)key - 60) >> (5 - newPartialParam->tvf.envTimeKeyfollow);
+		keyTimeSubtraction = (signed(key) - 60) >> (5 - newPartialParam->tvf.envTimeKeyfollow);
 	} else {
 		keyTimeSubtraction = 0;
 	}

--- a/mt32emu/src/TVP.cpp
+++ b/mt32emu/src/TVP.cpp
@@ -63,7 +63,7 @@ TVP::TVP(const Partial *usePartial) :
 static Bit16s keyToPitch(unsigned int key) {
 	// We're using a table to do: return round_to_nearest_or_even((key - 60) * (4096.0 / 12.0))
 	// Banker's rounding is just slightly annoying to do in C++
-	int k = (int)key;
+	int k = int(key);
 	Bit16s pitch = keyToPitchTable[abs(k - 60)];
 	return key < 60 ? -pitch : pitch;
 }
@@ -87,7 +87,7 @@ static Bit32u calcBasePitch(const Partial *partial, const TimbreParam::PartialPa
 
 	const ControlROMPCMStruct *controlROMPCMStruct = partial->getControlROMPCMStruct();
 	if (controlROMPCMStruct != NULL) {
-		basePitch += (Bit32s)((((Bit32s)controlROMPCMStruct->pitchMSB) << 8) | (Bit32s)controlROMPCMStruct->pitchLSB);
+		basePitch += (Bit32s(controlROMPCMStruct->pitchMSB) << 8) | Bit32s(controlROMPCMStruct->pitchLSB);
 	} else {
 		if ((partialParam->wg.waveform & 1) == 0) {
 			basePitch += 37133; // This puts Middle C at around 261.64Hz (assuming no other modifications, masterTune of 64, etc.)
@@ -103,7 +103,7 @@ static Bit32u calcBasePitch(const Partial *partial, const TimbreParam::PartialPa
 	if (basePitch > 59392) {
 		basePitch = 59392;
 	}
-	return (Bit32u)basePitch;
+	return Bit32u(basePitch);
 }
 
 static Bit32u calcVeloMult(Bit8u veloSensitivity, unsigned int velocity) {
@@ -124,7 +124,7 @@ static Bit32u calcVeloMult(Bit8u veloSensitivity, unsigned int velocity) {
 static Bit32s calcTargetPitchOffsetWithoutLFO(const TimbreParam::PartialParam *partialParam, int levelIndex, unsigned int velocity) {
 	int veloMult = calcVeloMult(partialParam->pitchEnv.veloSensitivity, velocity);
 	int targetPitchOffsetWithoutLFO = partialParam->pitchEnv.level[levelIndex] - 50;
-	targetPitchOffsetWithoutLFO = (Bit32s)(targetPitchOffsetWithoutLFO * veloMult) >> (16 - partialParam->pitchEnv.depth); // PORTABILITY NOTE: Assumes arithmetic shift
+	targetPitchOffsetWithoutLFO = (targetPitchOffsetWithoutLFO * veloMult) >> (16 - partialParam->pitchEnv.depth); // PORTABILITY NOTE: Assumes arithmetic shift
 	return targetPitchOffsetWithoutLFO;
 }
 
@@ -145,7 +145,7 @@ void TVP::reset(const Part *usePart, const TimbreParam::PartialParam *usePartial
 	phase = 0;
 
 	if (partialParam->pitchEnv.timeKeyfollow) {
-		timeKeyfollowSubtraction = (Bit32s)(key - 60) >> (5 - partialParam->pitchEnv.timeKeyfollow); // PORTABILITY NOTE: Assumes arithmetic shift
+		timeKeyfollowSubtraction = Bit32s(key - 60) >> (5 - partialParam->pitchEnv.timeKeyfollow); // PORTABILITY NOTE: Assumes arithmetic shift
 	} else {
 		timeKeyfollowSubtraction = 0;
 	}
@@ -183,7 +183,7 @@ void TVP::updatePitch() {
 			newPitch = 59392;
 		}
 	}
-	pitch = (Bit16u)newPitch;
+	pitch = Bit16u(newPitch);
 
 	// FIXME: We're doing this here because that's what the CM-32L does - we should probably move this somewhere more appropriate in future.
 	partial->getTVA()->recalcSustain();
@@ -321,7 +321,7 @@ void TVP::process() {
 		negativeBigTicksRemaining = negativeBigTicksRemaining >> rightShifts; // PORTABILITY NOTE: Assumes arithmetic shift
 		rightShifts = 13;
 	}
-	int newResult = ((Bit32s)(negativeBigTicksRemaining * pitchOffsetChangePerBigTick)) >> rightShifts; // PORTABILITY NOTE: Assumes arithmetic shift
+	int newResult = (negativeBigTicksRemaining * pitchOffsetChangePerBigTick) >> rightShifts; // PORTABILITY NOTE: Assumes arithmetic shift
 	newResult += targetPitchOffsetWithoutLFO + lfoPitchOffset;
 	currentPitchOffset = newResult;
 	updatePitch();

--- a/mt32emu/src/Tables.cpp
+++ b/mt32emu/src/Tables.cpp
@@ -33,18 +33,18 @@ Tables::Tables() {
 	int lf;
 	for (lf = 0; lf <= 100; lf++) {
 		// CONFIRMED:KG: This matches a ROM table found by Mok
-		float fVal = (2.0f - LOG10F((float)lf + 1.0f)) * 128.0f;
-		int val = (int)(fVal + 1.0);
+		float fVal = (2.0f - LOG10F(lf + 1.0f)) * 128.0f;
+		int val = int(fVal + 1.0);
 		if (val > 255) {
 			val = 255;
 		}
-		levelToAmpSubtraction[lf] = (Bit8u)val;
+		levelToAmpSubtraction[lf] = Bit8u(val);
 	}
 
 	envLogarithmicTime[0] = 64;
 	for (lf = 1; lf <= 255; lf++) {
 		// CONFIRMED:KG: This matches a ROM table found by Mok
-		envLogarithmicTime[lf] = (Bit8u)ceil(64.0f + LOG2F((float)lf) * 8.0f);
+		envLogarithmicTime[lf] = Bit8u(ceil(64.0f + LOG2F(float(lf)) * 8.0f));
 	}
 
 #if 0
@@ -65,12 +65,12 @@ Tables::Tables() {
 	// CONFIRMED: Based on a table found by Mok in the MT-32 control ROM
 	masterVolToAmpSubtraction[0] = 255;
 	for (int masterVol = 1; masterVol <= 100; masterVol++) {
-		masterVolToAmpSubtraction[masterVol] = (Bit8u)(106.31 - 16.0f * LOG2F((float)masterVol));
+		masterVolToAmpSubtraction[masterVol] = Bit8u(106.31 - 16.0f * LOG2F(float(masterVol)));
 	}
 #endif
 
 	for (int i = 0; i <= 100; i++) {
-		pulseWidth100To255[i] = (Bit8u)(i * 255 / 100.0f + 0.5f);
+		pulseWidth100To255[i] = Bit8u(i * 255 / 100.0f + 0.5f);
 		//synth->printDebug("%d: %d", i, pulseWidth100To255[i]);
 	}
 

--- a/mt32emu/src/sha1/sha1.cpp
+++ b/mt32emu/src/sha1/sha1.cpp
@@ -121,7 +121,7 @@ namespace sha1
         unsigned int result[5] = { 0x67452301, 0xefcdab89, 0x98badcfe, 0x10325476, 0xc3d2e1f0 };
 
         // Cast the void src pointer to be the byte array we can work with.
-        const unsigned char* sarray = (const unsigned char*) src;
+        const unsigned char* sarray = static_cast<const unsigned char*>(src);
 
         // The reusable round buffer
         unsigned int w[80];
@@ -139,10 +139,10 @@ namespace sha1
             for (int roundPos = 0; currentBlock < endCurrentBlock; currentBlock += 4)
             {
                 // This line will swap endian on big endian and keep endian on little endian.
-                w[roundPos++] = (unsigned int) sarray[currentBlock + 3]
-                        | (((unsigned int) sarray[currentBlock + 2]) << 8)
-                        | (((unsigned int) sarray[currentBlock + 1]) << 16)
-                        | (((unsigned int) sarray[currentBlock]) << 24);
+                w[roundPos++] = static_cast<unsigned int>(sarray[currentBlock + 3])
+                        | (static_cast<unsigned int>(sarray[currentBlock + 2]) << 8)
+                        | (static_cast<unsigned int>(sarray[currentBlock + 1]) << 16)
+                        | (static_cast<unsigned int>(sarray[currentBlock]) << 24);
             }
             innerHash(result, w);
         }
@@ -153,7 +153,7 @@ namespace sha1
         int lastBlockBytes = 0;
         for (;lastBlockBytes < endCurrentBlock; ++lastBlockBytes)
         {
-            w[lastBlockBytes >> 2] |= (unsigned int) sarray[lastBlockBytes + currentBlock] << ((3 - (lastBlockBytes & 3)) << 3);
+            w[lastBlockBytes >> 2] |= static_cast<unsigned int>(sarray[lastBlockBytes + currentBlock]) << ((3 - (lastBlockBytes & 3)) << 3);
         }
         w[lastBlockBytes >> 2] |= 0x80 << ((3 - (lastBlockBytes & 3)) << 3);
         if (endCurrentBlock >= 56)


### PR DESCRIPTION
I have eliminated all warnings in mt32emu relating to casts in these categories:

- C-style casts [-Wold-style-cast];
- useless casts [-Wuseless-cast].

As a consequence, I changed the handling of a cast to enum in mt32emu/src/LA32WaveGenerator.* to a form that does not evoke undefined behavior: enums do not necessarily use int for storage, they can use less. As a bonus, the new form is marginally more efficient.