### PR TITLE
fix Ubuntu default warning [-Werror=format-security] in dosbox patch

### DIFF
--- a/DOSBox-mt32-patch/dosbox-0.74-mt32-patch.diff
+++ b/DOSBox-mt32-patch/dosbox-0.74-mt32-patch.diff
@@ -331,7 +331,7 @@ index 0000000..eb8bf8f
 +		char s[1024];
 +		strcpy(s, "MT32: ");
 +		vsnprintf(s + 6, 1017, fmt, list);
-+		LOG_MSG(s);
++		LOG_MSG("%s", s);
 +	}
 +}
 diff --git a/src/gui/midi_mt32.h b/src/gui/midi_mt32.h

--- a/DOSBox-mt32-patch/dosbox-SVN-r3892-mt32-patch.diff
+++ b/DOSBox-mt32-patch/dosbox-SVN-r3892-mt32-patch.diff
@@ -329,7 +329,7 @@ index 0000000..eb8bf8f
 +		char s[1024];
 +		strcpy(s, "MT32: ");
 +		vsnprintf(s + 6, 1017, fmt, list);
-+		LOG_MSG(s);
++		LOG_MSG("%s", s);
 +	}
 +}
 diff --git a/src/gui/midi_mt32.h b/src/gui/midi_mt32.h


### PR DESCRIPTION
Ubuntu defaults (used on launchpad for example, if you use the simple debian/rules, which is where i triggered it) has a warning turn into a error. This warning exists once on the Dosbox patches, which i import automatically.

> g++ -DHAVE_CONFIG_H -I. -I../..  -I../../include -D_FORTIFY_SOURCE=2 -D_FILE_OFFSET_BITS=64 -I/usr/include/SDL -D_GNU_SOURCE=1 -D_REENTRANT  -g -O2 -fstack-protector-strong -Wformat -Werror=format-security -mno-ms-bitfields  -c -o midi_mt32.o midi_mt32.cpp
> midi_mt32.cpp: In member function ‘virtual void MidiHandler_mt32::MT32ReportHandler::printDebug(const char*, va_list)’:
> midi_mt32.cpp:263:12: error: format not a string literal and no format arguments [-Werror=format-security]
>    LOG_MSG(s);
>             ^

This was fixed in the lamest way possible and i'm not very confident that the 'issue' - that i know didn't exist since vsnprintf leaves a \0 at the end - wouldn't still happen if that vsnprintf thing didn't happen. It's so lame that i encourage you to look at it and get a better 30 seconds solution than the lame redirect i did, if you can. I certainly remember less than nothing about c and c++ string functions.

However, it did apply and compile without that error.