### PR TITLE
Fixing bugs found by static analyzer

### DIFF
--- a/mt32emu/src/PartialManager.cpp
+++ b/mt32emu/src/PartialManager.cpp
@@ -280,7 +280,7 @@ void PartialManager::polyFreed(Poly *poly) {
 			const Poly *activePoly = synth->getPart(partNum)->getFirstActivePoly();
 			Bit32u polyCount = 0;
 			while (activePoly != NULL) {
-				activePoly->getNext();
+				activePoly = activePoly->getNext();
 				polyCount++;
 			}
 			synth->printDebug("Part: %i, active poly count: %i\n", partNum, polyCount);

--- a/mt32emu/src/Synth.cpp
+++ b/mt32emu/src/Synth.cpp
@@ -2093,6 +2093,7 @@ void MemoryRegion::write(unsigned int entry, unsigned int off, const Bit8u *src,
 #if MT32EMU_MONITOR_SYSEX > 0
 		synth->printDebug("write[%d]: unwritable region: entry=%d, off=%d, len=%d", type, entry, off, len);
 #endif
+		return;
 	}
 
 	for (unsigned int i = 0; i < len; i++) {


### PR DESCRIPTION
The loop is essentially endless, unless the compiler happens to use the same register for the loop variable as it does for the function return.