### PR TITLE
Expose calcSysexChecksum and playSysexWithoutFraming in C interfaces

### DIFF
--- a/mt32emu/src/c_interface/c_interface.cpp
+++ b/mt32emu/src/c_interface/c_interface.cpp
@@ -328,6 +328,10 @@ mt32emu_bit32u mt32emu_get_stereo_output_samplerate(const mt32emu_analog_output_
 	return Synth::getStereoOutputSampleRate(static_cast<AnalogOutputMode>(analog_output_mode));
 }
 
+mt32emu_bit8u mt32emu_calc_sysex_checksum(const mt32emu_bit8u *data, const mt32emu_bit32u len, const mt32emu_bit8u initChecksum) {
+	return Synth::calcSysexChecksum(data, len, initChecksum);
+}
+
 mt32emu_context mt32emu_create_context(mt32emu_report_handler_i report_handler, void *instance_data) {
 	mt32emu_data *data = new mt32emu_data;
 	data->reportHandler = (report_handler.v0 != NULL) ? new DelegatingReportHandlerAdapter(report_handler, instance_data) : new ReportHandler;
@@ -477,6 +481,12 @@ mt32emu_return_code mt32emu_play_msg(mt32emu_const_context context, mt32emu_bit3
 mt32emu_return_code mt32emu_play_sysex(mt32emu_const_context context, const mt32emu_bit8u *sysex, mt32emu_bit32u len) {
 	if (!context->synth->isOpen()) return MT32EMU_RC_NOT_OPENED;
 	return (context->synth->playSysex(sysex, len)) ? MT32EMU_RC_OK : MT32EMU_RC_QUEUE_FULL;
+}
+
+mt32emu_return_code mt32emu_play_sysex_without_framing(mt32emu_const_context context, const mt32emu_bit8u *sysex, mt32emu_bit32u len) {
+	if (!context->synth->isOpen()) return MT32EMU_RC_NOT_OPENED;
+	context->synth->playSysexWithoutFraming(sysex, len);
+	return MT32EMU_RC_OK;
 }
 
 mt32emu_return_code mt32emu_play_msg_at(mt32emu_const_context context, mt32emu_bit32u msg, mt32emu_bit32u timestamp) {

--- a/mt32emu/src/c_interface/c_interface.h
+++ b/mt32emu/src/c_interface/c_interface.h
@@ -73,6 +73,9 @@ MT32EMU_EXPORT const char *mt32emu_get_library_version_string();
  */
 MT32EMU_EXPORT mt32emu_bit32u mt32emu_get_stereo_output_samplerate(const mt32emu_analog_output_mode analog_output_mode);
 
+/** Calculates and returns the checksum of the given sysex message. */
+MT32EMU_EXPORT mt32emu_bit8u mt32emu_calc_sysex_checksum(const mt32emu_bit8u *data, const mt32emu_bit32u len, const mt32emu_bit8u initChecksum);
+
 /* == Context-dependent functions == */
 
 /** Initialises a new emulation context and installs custom report handler if non-NULL. */
@@ -195,6 +198,8 @@ MT32EMU_EXPORT void mt32emu_play_short_message_at(mt32emu_const_context context,
 MT32EMU_EXPORT mt32emu_return_code mt32emu_play_msg(mt32emu_const_context context, mt32emu_bit32u msg);
 /** Enqueues a single well formed System Exclusive MIDI message to be processed ASAP. */
 MT32EMU_EXPORT mt32emu_return_code mt32emu_play_sysex(mt32emu_const_context context, const mt32emu_bit8u *sysex, mt32emu_bit32u len);
+/** Enqueues a frameless System Exclusive MIDI message to be processed ASAP. */
+MT32EMU_EXPORT mt32emu_return_code mt32emu_play_sysex_without_framing(mt32emu_const_context context, const mt32emu_bit8u *sysex, mt32emu_bit32u len);
 
 /** Enqueues a single short MIDI message to play at specified time. The message must contain a status byte. */
 MT32EMU_EXPORT mt32emu_return_code mt32emu_play_msg_at(mt32emu_const_context context, mt32emu_bit32u msg, mt32emu_bit32u timestamp);

--- a/mt32emu/src/c_interface/cpp_interface.h
+++ b/mt32emu/src/c_interface/cpp_interface.h
@@ -33,6 +33,7 @@
 #define mt32emu_get_library_version_int i.v0->getLibraryVersionInt
 #define mt32emu_get_library_version_string i.v0->getLibraryVersionString
 #define mt32emu_get_stereo_output_samplerate i.v0->getStereoOutputSamplerate
+#define mt32emu_calc_sysex_checksum i.v0->calcSysexChecksum
 #define mt32emu_create_context i.v0->createContext
 #define mt32emu_free_context i.v0->freeContext
 #define mt32emu_add_rom_data i.v0->addROMData
@@ -55,6 +56,7 @@
 #define mt32emu_play_sysex i.v0->playSysex
 #define mt32emu_play_msg_at i.v0->playMsgAt
 #define mt32emu_play_sysex_at i.v0->playSysexAt
+#define mt32emu_play_sysex_without_framing i.v0->playSysexWithoutFraming
 #define mt32emu_play_msg_now i.v0->playMsgNow
 #define mt32emu_play_msg_on_part i.v0->playMsgOnPart
 #define mt32emu_play_sysex_now i.v0->playSysexNow
@@ -172,6 +174,8 @@ public:
 
 	Bit32u getStereoOutputSamplerate(const AnalogOutputMode analog_output_mode) { return mt32emu_get_stereo_output_samplerate(static_cast<mt32emu_analog_output_mode>(analog_output_mode)); }
 
+	Bit8u calcSysexChecksum(const Bit8u *data, const Bit32u len, const Bit8u initChecksum) { return mt32emu_calc_sysex_checksum(data, len, initChecksum); }
+
 	// Context-dependent methods
 
 	mt32emu_context getContext() { return c; }
@@ -200,6 +204,7 @@ public:
 	mt32emu_return_code playSysex(const Bit8u *sysex, Bit32u len) { return mt32emu_play_sysex(c, sysex, len); }
 	mt32emu_return_code playMsgAt(Bit32u msg, Bit32u timestamp) { return mt32emu_play_msg_at(c, msg, timestamp); }
 	mt32emu_return_code playSysexAt(const Bit8u *sysex, Bit32u len, Bit32u timestamp) { return mt32emu_play_sysex_at(c, sysex, len, timestamp); }
+	mt32emu_return_code playSysexWithoutFraming(const Bit8u *sysex, Bit32u len) { return mt32emu_play_sysex_without_framing(c, sysex, len); }
 
 	void playMsgNow(Bit32u msg) { mt32emu_play_msg_now(c, msg); }
 	void playMsgOnPart(Bit8u part, Bit8u code, Bit8u note, Bit8u velocity) { mt32emu_play_msg_on_part(c, part, code, note, velocity); }
@@ -375,6 +380,7 @@ static mt32emu_midi_receiver_i getMidiReceiverThunk() {
 #undef mt32emu_get_library_version_int
 #undef mt32emu_get_library_version_string
 #undef mt32emu_get_stereo_output_samplerate
+#undef mt32emu_calc_sysex_checksum
 #undef mt32emu_create_context
 #undef mt32emu_free_context
 #undef mt32emu_add_rom_data
@@ -397,6 +403,7 @@ static mt32emu_midi_receiver_i getMidiReceiverThunk() {
 #undef mt32emu_play_sysex
 #undef mt32emu_play_msg_at
 #undef mt32emu_play_sysex_at
+#undef mt32emu_play_sysex_without_framing
 #undef mt32emu_play_msg_now
 #undef mt32emu_play_msg_on_part
 #undef mt32emu_play_sysex_now


### PR DESCRIPTION
These functions are used by the MT32 driver in ScummVM, but aren’t exposed through the new C/C++ interfaces. This patch assumes that not exposing these was an oversight, but let me know if they were intentionally omitted and there is a different API that should be used instead.