### PR TITLE
Fix Set-But-Unused Compiler Warning.

### DIFF
--- a/mt32emu/src/File.cpp
+++ b/mt32emu/src/File.cpp
@@ -24,11 +24,11 @@
 
 namespace MT32Emu {
 
-AbstractFile::AbstractFile() : sha1DigestCalculated(false), reserved(NULL) {
+AbstractFile::AbstractFile() : sha1DigestCalculated(false) {
 	sha1Digest[0] = 0;
 }
 
-AbstractFile::AbstractFile(const SHA1Digest &useSHA1Digest) : sha1DigestCalculated(true), reserved(NULL) {
+AbstractFile::AbstractFile(const SHA1Digest &useSHA1Digest) : sha1DigestCalculated(true) {
 	memcpy(sha1Digest, useSHA1Digest, sizeof(SHA1Digest) - 1);
 	sha1Digest[sizeof(SHA1Digest) - 1] = 0; // Ensure terminator char.
 }

--- a/mt32emu/src/File.h
+++ b/mt32emu/src/File.h
@@ -49,9 +49,6 @@ protected:
 private:
 	bool sha1DigestCalculated;
 	SHA1Digest sha1Digest;
-
-	// Binary compatibility helper.
-	void *reserved;
 };
 
 class MT32EMU_EXPORT ArrayFile : public AbstractFile {


### PR DESCRIPTION
This removes some dead code from the MT32 Emulator File Classes, which has no functional change, but stops various compilers warning about this dead code.

This is as per ScummVM commit:
https://github.com/scummvm/scummvm/commit/77818e968392301eacf718a56518ea1b63815c72