### PR TITLE
Fix case of Types.h include

### DIFF
--- a/mt32emu/src/SampleRateConverter.h
+++ b/mt32emu/src/SampleRateConverter.h
@@ -18,7 +18,7 @@
 #define SAMPLE_RATE_CONVERTER_H
 
 #include "globals.h"
-#include "types.h"
+#include "Types.h"
 #include "Enumerations.h"
 
 namespace MT32Emu {


### PR DESCRIPTION
This fixes the case of an include to fix building on Linux.