### PR TITLE
dosbox-svn patch: make chunk, prebuffer and partials fully configurable

### DIFF
--- a/DOSBox-mt32-patch/dosbox-SVN-r4025-mt32-patch.diff
+++ b/DOSBox-mt32-patch/dosbox-SVN-r4025-mt32-patch.diff
@@ -423,10 +423,10 @@ index 0000000..eb32729
 +#endif /* DOSBOX_MIDI_MT32_H */
 diff --git a/src/mt32options.h b/src/mt32options.h
 new file mode 100644
-index 0000000..c1efa29
+index 00000000..6292f0b6
 --- /dev/null
 +++ b/src/mt32options.h
-@@ -0,0 +1,115 @@
+@@ -0,0 +1,109 @@
 +Pstring = secprop->Add_string("mt32.romdir",Property::Changeable::WhenIdle,"");
 +Pstring->Set_help("Name of the directory where MT-32 Control and PCM ROM files can be found. Emulation requires these files to work.\n"
 +	"  Accepted file names are as follows:\n"
@@ -442,28 +442,22 @@ index 0000000..c1efa29
 +Pbool = secprop->Add_bool("mt32.thread",Property::Changeable::WhenIdle,false);
 +Pbool->Set_help("MT-32 rendering in separate thread");
 +
-+const char *mt32chunk[] = {"2", "3", "16", "99", "100",0};
 +Pint = secprop->Add_int("mt32.chunk",Property::Changeable::WhenIdle,16);
-+Pint->Set_values(mt32chunk);
 +Pint->SetMinMax(2,100);
-+Pint->Set_help("Minimum milliseconds of data to render at once.\n"
++Pint->Set_help("Minimum milliseconds of data to render at once. (min 2, max 100)\n"
 +	"Increasing this value reduces rendering overhead which may improve performance but also increases audio lag.\n"
 +	"Valid for rendering in separate thread only.");
 +
-+const char *mt32prebuffer[] = {"3", "4", "32", "199", "200",0};
 +Pint = secprop->Add_int("mt32.prebuffer",Property::Changeable::WhenIdle,32);
-+Pint->Set_values(mt32prebuffer);
 +Pint->SetMinMax(3,200);
-+Pint->Set_help("How many milliseconds of data to render ahead.\n"
++Pint->Set_help("How many milliseconds of data to render ahead. (min 3, max 200)\n"
 +	"Increasing this value may help to avoid underruns but also increases audio lag.\n"
 +	"Cannot be set less than or equal to mt32.chunk value.\n"
 +	"Valid for rendering in separate thread only.");
 +
-+const char *mt32partials[] = {"8", "9", "32", "255", "256",0};
 +Pint = secprop->Add_int("mt32.partials",Property::Changeable::WhenIdle,32);
-+Pint->Set_values(mt32partials);
 +Pint->SetMinMax(8,256);
-+Pint->Set_help("The maximum number of partials playing simultaneously.");
++Pint->Set_help("The maximum number of partials playing simultaneously. (min 8, max 256");
 +
 +const char *mt32DACModes[] = {"0", "1", "2", "3",0};
 +Pint = secprop->Add_int("mt32.dac",Property::Changeable::WhenIdle,0);


### PR DESCRIPTION
It is currently not possible to set any of these options to any other value other than the ones provided as examples. Any other values are rejected by dosbox.

This fixes the dosbox-svn patch to allow any value that's within the specified range and also documents the range (as dosbox doesn't currently automatically emit value range documentation.)