### PR TITLE
Add code to select output device on macOS CoreAudio driver

### DIFF
--- a/mt32emu_qt/src/audiodrv/CoreAudioDriver.cpp
+++ b/mt32emu_qt/src/audiodrv/CoreAudioDriver.cpp
@@ -23,6 +23,26 @@ static const uint DEFAULT_CHUNK_MS = 20;
 static const uint DEFAULT_AUDIO_LATENCY = 60;
 static const uint DEFAULT_MIDI_LATENCY = 30;
 
+// For Qt versions < 5.2
+// Taken from Qt 5.2 source code
+// File: qtbase/src/corelib/tools/qstring_mac.mm
+static QString convertCFStringToQString(CFStringRef string)
+{
+    if (!string)
+        return QString();
+    CFIndex length = CFStringGetLength(string);
+    
+    // Fast path: CFStringGetCharactersPtr does not copy but may
+    // return null for any and no reason.
+    const UniChar *chars = CFStringGetCharactersPtr(string);
+    if (chars)
+        return QString(reinterpret_cast<const QChar *>(chars), length);
+    
+    QString ret(length, Qt::Uninitialized);
+    CFStringGetCharacters(string, CFRangeMake(0, length), reinterpret_cast<UniChar *>(ret.data()));
+    return ret;
+}
+
 CoreAudioStream::CoreAudioStream(const AudioDriverSettings &useSettings, QSynth &useSynth, quint32 useSampleRate, const QString deviceUid) :
 	AudioStream(useSettings, useSynth, useSampleRate), audioQueue(NULL), deviceUid(deviceUid)
 {
@@ -197,8 +217,13 @@ const QList<const AudioDevice *> CoreAudioDriver::createDeviceList() {
                             
                             if (AudioObjectGetPropertyData(id, &deviceAddress, 0, NULL, &propertySize, &devNameRef) == noErr) {
                                 QString uid, name;
+#if QT_VERSION >= QT_VERSION_CHECK(5, 2, 0)
                                 uid = QString::fromCFString(devUidRef);
                                 name = QString::fromCFString(devNameRef);
+#else
+                                uid = convertCFStringToQString(devUidRef);
+                                name = convertCFStringToQString(devNameRef);
+#endif
                                 deviceList.append(new CoreAudioDevice(*this, uid, name));
                             }
                             CFRelease(devNameRef);

--- a/mt32emu_qt/src/audiodrv/CoreAudioDriver.cpp
+++ b/mt32emu_qt/src/audiodrv/CoreAudioDriver.cpp
@@ -43,8 +43,8 @@ static QString convertCFStringToQString(CFStringRef string)
     return ret;
 }
 
-CoreAudioStream::CoreAudioStream(const AudioDriverSettings &useSettings, QSynth &useSynth, quint32 useSampleRate, const QString deviceUid) :
-	AudioStream(useSettings, useSynth, useSampleRate), audioQueue(NULL), deviceUid(deviceUid)
+CoreAudioStream::CoreAudioStream(const AudioDriverSettings &useSettings, QSynth &useSynth, quint32 useSampleRate) :
+	AudioStream(useSettings, useSynth, useSampleRate), audioQueue(NULL)
 {
 	const uint bufferSize = (settings.chunkLen * sampleRate) / MasterClock::MILLIS_PER_SECOND;
 	bufferByteSize = bufferSize << 2;
@@ -93,7 +93,7 @@ void CoreAudioStream::renderOutputBuffer(void *userData, AudioQueueRef queue, Au
 	if (res) qDebug() << "CoreAudio: AudioQueueEnqueueBuffer() failed with error code:" << res;
 }
 
-bool CoreAudioStream::start() {
+bool CoreAudioStream::start(const QString deviceUid) {
 	if (audioQueue != NULL) {
 		return true;
 	}
@@ -158,8 +158,8 @@ CoreAudioDevice::CoreAudioDevice(CoreAudioDriver &driver, const QString uid, con
 	AudioDevice(driver, name), uid(uid) {}
 
 AudioStream *CoreAudioDevice::startAudioStream(QSynth &synth, const uint sampleRate) const {
-	CoreAudioStream *stream = new CoreAudioStream(driver.getAudioSettings(), synth, sampleRate, uid);
-	if (stream->start()) {
+	CoreAudioStream *stream = new CoreAudioStream(driver.getAudioSettings(), synth, sampleRate);
+	if (stream->start(uid)) {
 		return (AudioStream *)stream;
 	}
 	delete stream;

--- a/mt32emu_qt/src/audiodrv/CoreAudioDriver.h
+++ b/mt32emu_qt/src/audiodrv/CoreAudioDriver.h
@@ -2,6 +2,7 @@
 #define CORE_AUDIO_DRIVER_H
 
 #include <AudioToolbox/AudioQueue.h>
+#include <CoreAudio/AudioHardware.h>
 
 #include "AudioDriver.h"
 
@@ -15,11 +16,12 @@ private:
 	AudioQueueBufferRef *buffers;
 	uint numberOfBuffers;
 	uint bufferByteSize;
+    const QString deviceUid;
 
 	static void renderOutputBuffer(void *userData, AudioQueueRef queue, AudioQueueBufferRef buffer);
 
 public:
-	CoreAudioStream(const AudioDriverSettings &settings, QSynth &synth, const quint32 sampleRate);
+	CoreAudioStream(const AudioDriverSettings &settings, QSynth &synth, const quint32 sampleRate, const QString deviceUid = NULL);
 	~CoreAudioStream();
 	bool start();
 	void close();
@@ -28,7 +30,9 @@ public:
 class CoreAudioDevice : public AudioDevice {
 friend class CoreAudioDriver;
 private:
-	CoreAudioDevice(CoreAudioDriver &driver);
+    const QString uid;
+    
+	CoreAudioDevice(CoreAudioDriver &driver, const QString uid = NULL, const QString name = "Default output device");
 
 public:
 	AudioStream *startAudioStream(QSynth &synth, const uint sampleRate) const;


### PR DESCRIPTION
I tried to implement output device selection for CoreAudio driver on macOS.

Any inputs/suggestions are welcome.

Thanks