### PR TITLE
Silence GCC compiler warnings

### DIFF
--- a/mt32emu/src/Analog.cpp
+++ b/mt32emu/src/Analog.cpp
@@ -273,6 +273,8 @@ Analog *Analog::createAnalog(const AnalogOutputMode mode, const bool oldMT32Anal
 		return new AnalogImpl<IntSampleEx>(mode, oldMT32AnalogLPF);
 	case RendererType_FLOAT:
 		return new AnalogImpl<FloatSample>(mode, oldMT32AnalogLPF);
+	default:
+		break;
 	}
 	return NULL;
 }

--- a/mt32emu/src/BReverbModel.cpp
+++ b/mt32emu/src/BReverbModel.cpp
@@ -633,6 +633,8 @@ BReverbModel *BReverbModel::createBReverbModel(const ReverbMode mode, const bool
 		return new BReverbModelImpl<IntSample>(mode, mt32CompatibleModel);
 	case RendererType_FLOAT:
 		return new BReverbModelImpl<FloatSample>(mode, mt32CompatibleModel);
+	default:
+		break;
 	}
 	return NULL;
 }

--- a/mt32emu/src/Synth.cpp
+++ b/mt32emu/src/Synth.cpp
@@ -1674,6 +1674,8 @@ void Synth::writeMemoryRegion(const MemoryRegion *region, Bit32u addr, Bit32u le
 	case MR_Reset:
 		reset();
 		break;
+	default:
+		break;
 	}
 }
 

--- a/mt32emu/src/TVF.cpp
+++ b/mt32emu/src/TVF.cpp
@@ -206,6 +206,8 @@ void TVF::nextPhase() {
 		}
 		startRamp((levelMult * partialParam->tvf.envLevel[3]) >> 8, 0, newPhase);
 		return;
+	default:
+		break;
 	}
 
 	int envPointIndex = phase;


### PR DESCRIPTION
This patch adds a few missing `default` cases, silencing the matching GCC compiler warnings.