### PR TITLE
Generate and install a pkg-config file

### DIFF
--- a/mt32emu/CMakeLists.txt
+++ b/mt32emu/CMakeLists.txt
@@ -168,6 +168,8 @@ endforeach(HEADER)
 configure_file("src/config.h.in" "include/mt32emu/config.h")
 include_directories(${CMAKE_CURRENT_BINARY_DIR}/include/mt32emu)
 
+configure_file("src/mt32emu.pc.in" "mt32emu.pc" @ONLY)
+
 if(${PROJECT_NAME}_WITH_INTERNAL_RESAMPLER)
   add_definitions(-DMT32EMU_WITH_INTERNAL_RESAMPLER)
   set(${PROJECT_NAME}_SOURCES ${${PROJECT_NAME}_SOURCES}
@@ -263,6 +265,10 @@ if(NOT(libmt32emu_SHARED AND libmt32emu_PACKAGE_TYPE STREQUAL "Devel"))
   install(FILES
     AUTHORS.txt COPYING.txt COPYING.LESSER.txt NEWS.txt README.md TODO.txt
     DESTINATION share/doc/munt/libmt32emu
+  )
+  install(FILES 
+    ${CMAKE_CURRENT_BINARY_DIR}/mt32emu.pc
+    DESTINATION ${LIB_INSTALL_DIR}/pkgconfig
   )
 endif()
 

--- a/mt32emu/src/mt32emu.pc.in
+++ b/mt32emu/src/mt32emu.pc.in
@@ -1,0 +1,10 @@
+prefix=@CMAKE_INSTALL_PREFIX@
+exec_prefix=${prefix}
+libdir=${exec_prefix}/@CMAKE_INSTALL_LIBDIR@
+includedir=${prefix}/include/mt32emu
+
+Name: libmt32emu
+Description: a C/C++ library which allows to emulate (approximately) the Roland MT-32, CM-32L and LAPC-I synthesiser modules
+Version: @libmt32emu_VERSION@
+Libs: -L${libdir} -lmt32emu
+Cflags: -I${includedir}

--- a/mt32emu/src/mt32emu.pc.in
+++ b/mt32emu/src/mt32emu.pc.in
@@ -1,10 +1,11 @@
 prefix=@CMAKE_INSTALL_PREFIX@
 exec_prefix=${prefix}
-libdir=${exec_prefix}/@CMAKE_INSTALL_LIBDIR@
-includedir=${prefix}/include/mt32emu
+libdir=${exec_prefix}/@LIB_INSTALL_DIR@
+includedir=${prefix}/include
 
 Name: libmt32emu
+URL: http://munt.sourceforge.net
 Description: a C/C++ library which allows to emulate (approximately) the Roland MT-32, CM-32L and LAPC-I synthesiser modules
 Version: @libmt32emu_VERSION@
 Libs: -L${libdir} -lmt32emu
-Cflags: -I${includedir}
+Cflags: -I${includedir}/mt32emu


### PR DESCRIPTION
I've struggled a bit with cflags etc. and found that a pkg-config file could be useful and is not that hard to have it autofill a template and install it.
Not sure where to put the template, so for now put it in mt32emu/src.
Likewise I wasn't sure whether to name the pkg-config file similar to the actual library name (libmt32emu.pc). For now I've named it mt32emu.pc.

Please let me know if you need something changed.