### PR TITLE
Fix effc++ warnings in libmt32emu interface

### DIFF
--- a/mt32emu/src/c_interface/cpp_interface.h
+++ b/mt32emu/src/c_interface/cpp_interface.h
@@ -301,6 +301,9 @@ private:
 	const mt32emu_service_i_v3 *iV3() { return (getVersionID() < MT32EMU_SERVICE_VERSION_3) ? NULL : i.v3; }
 	const mt32emu_service_i_v4 *iV4() { return (getVersionID() < MT32EMU_SERVICE_VERSION_4) ? NULL : i.v4; }
 #endif
+
+	Service(const Service &);            // prevent copy-construction
+	Service& operator=(const Service &); // prevent assignment
 };
 
 namespace CppInterfaceImpl {


### PR DESCRIPTION
When users of the library compile code with -Weffc++, this class
triggers warning:

  ‘class MT32Emu::Service’ has pointer data members
  but does not declare ‘MT32Emu::Service(const MT32Emu::Service&)’
  or ‘operator=(const MT32Emu::Service&)’

Class Service aggregates an owning raw pointer (mt32emu_context), which
is being taken over via constructor and freed in destructor - this might
lead user to accidentally double free the pointed object if a Service
object was accidentally copied through default copy c-tor or default
assignment operator.

Declare copy c-tor and operator= private to prevent creation of
accidental copy (this fixes the warning).

When upgrading this code to C++11, these declarations should be
marked with '= delete' (and won't need to be private any more).