### PR TITLE
Fix CoreAudio element name gating

### DIFF
--- a/mt32emu_qt/src/audiodrv/CoreAudioDriver.cpp
+++ b/mt32emu_qt/src/audiodrv/CoreAudioDriver.cpp
@@ -188,10 +188,10 @@ const QList<const AudioDevice *> CoreAudioDriver::createDeviceList() {
 	QList<const AudioDevice *> deviceList;
 	deviceList.append(new CoreAudioDevice(*this)); // default device
 
-#if MAC_OS_X_VERSION_MIN_REQUIRED < MAC_OS_VERSION_12_0
-	AudioObjectPropertyElement addressElement = kAudioObjectPropertyElementMaster;
-#else
+#if defined(MAC_OS_VERSION_12_0) && (MAC_OS_X_VERSION_MIN_REQUIRED >= MAC_OS_VERSION_12_0)
 	AudioObjectPropertyElement addressElement = kAudioObjectPropertyElementMain;
+#else
+	AudioObjectPropertyElement addressElement = kAudioObjectPropertyElementMaster;
 #endif
 
 	// Get system output devices


### PR DESCRIPTION
https://github.com/munt/munt/commit/0d876889ced8fdd0927aeeca7089cf774ceafa77 broke building on older SDK that doesn't know about `MAC_OS_VERSION_12_0`.

A failed CI run of mt32emu_qt_1_11_0 from my downstream bump in Nixpkgs: https://logs.nix.ci/?key=nixos/nixpkgs.184841&attempt_id=25fa34ec-86c4-44df-97d1-1ef69ce1b6f1
```
[ 85%] Building CXX object mt32emu_qt/CMakeFiles/mt32emu-qt.dir/src/audiodrv/CoreAudioDriver.cpp.o
/tmp/nix-build-mt32emu-qt-1.11.0.drv-0/source/mt32emu_qt/src/audiodrv/CoreAudioDriver.cpp:194:46: error: use of undeclared identifier 'kAudioObjectPropertyElementMain'; did you mean 'kAudioObjectPropertyElementName'?
        AudioObjectPropertyElement addressElement = kAudioObjectPropertyElementMain;
                                                    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
                                                    kAudioObjectPropertyElementName
```
This is because the `Libsystem` we have is from 10.12 (in the process of getting updated) and obviously doesn't know about `MAC_OS_VERSION_12_0`.

The following is also how RtAudio handles this check: https://github.com/thestk/rtaudio/commit/3448ed36b773ff638cc90cf87cb77d0fb8ecf7d9