### PR TITLE
Fix segmentation fault on MSYS2 Clang on Windows

### DIFF
--- a/mt32emu/src/ROMInfo.h
+++ b/mt32emu/src/ROMInfo.h
@@ -30,7 +30,7 @@ namespace MT32Emu {
 struct ROMInfo {
 public:
 	size_t fileSize;
-	const File::SHA1Digest &sha1Digest;
+	const char *sha1Digest;
 	enum Type {PCM, Control, Reverb} type;
 	const char *shortName;
 	const char *description;


### PR DESCRIPTION
Hello, I am a Dosbox Staging developer and I noticed a segmentation fault that happens when building Munt from source with MSYS2 Clang on Windows.

I could not reproduce this with MSYS2 using GCC or on any builds on Linux so I assume this configuration may not have been tested.

I stepped through the code where the ROMInfo structs get initialized and these get initialized with invalid pointers for the `sha1Digest` member:

https://github.com/munt/munt/blob/e6af0c7e5d63680716ab350467207c938054a0df/mt32emu/src/ROMInfo.cpp#L56-L79

It appears `File::SHA1Digest` is a typedef to `char[41]`.  Changing the type from a reference to char array to a `const char *` resolves the issue.