### PR TITLE
`Tables` and `LA32Utilties` optimizations

### DIFF
--- a/mt32emu/src/LA32FloatWaveGenerator.cpp
+++ b/mt32emu/src/LA32FloatWaveGenerator.cpp
@@ -202,7 +202,7 @@ float LA32FloatWaveGenerator::generateNextSample(const Bit32u ampVal, const Bit1
 			float resSample = 1.0f;
 
 			// Resonance decay speed factor
-			float resAmpDecayFactor = Tables::getInstance().resAmpDecayFactor[resonance >> 2];
+			float resAmpDecayFactor = Tables::resAmpDecayFactor[resonance >> 2];
 
 			// Now relWavePos counts from the middle of first cosine
 			relWavePos = wavePos;

--- a/mt32emu/src/LA32Ramp.cpp
+++ b/mt32emu/src/LA32Ramp.cpp
@@ -85,7 +85,7 @@ void LA32Ramp::startRamp(Bit8u target, Bit8u increment) {
 		// Three bits in the fractional part, no need to interpolate
 		// (unsigned int)(EXP2F(((increment & 0x7F) + 24) / 8.0f) + 0.125f)
 		Bit32u expArg = increment & 0x7F;
-		largeIncrement = 8191 - Tables::getInstance().exp9[~(expArg << 6) & 511];
+		largeIncrement = 8191 - Tables::exp9[~(expArg << 6) & 511];
 		largeIncrement <<= expArg >> 3;
 		largeIncrement += 64;
 		largeIncrement >>= 9;

--- a/mt32emu/src/LA32WaveGenerator.cpp
+++ b/mt32emu/src/LA32WaveGenerator.cpp
@@ -30,28 +30,6 @@ static const Bit32u RESONANCE_DECAY_THRESHOLD_CUTOFF_VALUE = 144 << 18;
 static const Bit32u MAX_CUTOFF_VALUE = 240 << 18;
 static const LogSample SILENCE = {65535, LogSample::POSITIVE};
 
-Bit16u LA32Utilites::interpolateExp(const Bit16u fract) {
-	Bit16u expTabIndex = fract >> 3;
-	Bit16u extraBits = ~fract & 7;
-	Bit16u expTabEntry2 = 8191 - Tables::getInstance().exp9[expTabIndex];
-	Bit16u expTabEntry1 = expTabIndex == 0 ? 8191 : (8191 - Tables::getInstance().exp9[expTabIndex - 1]);
-	return expTabEntry2 + (((expTabEntry1 - expTabEntry2) * extraBits) >> 3);
-}
-
-Bit16s LA32Utilites::unlog(const LogSample &logSample) {
-	//Bit16s sample = (Bit16s)EXP2F(13.0f - logSample.logValue / 1024.0f);
-	Bit32u intLogValue = logSample.logValue >> 12;
-	Bit16u fracLogValue = logSample.logValue & 4095;
-	Bit16s sample = interpolateExp(fracLogValue) >> intLogValue;
-	return logSample.sign == LogSample::POSITIVE ? sample : -sample;
-}
-
-void LA32Utilites::addLogSamples(LogSample &logSample1, const LogSample &logSample2) {
-	Bit32u logSampleValue = logSample1.logValue + logSample2.logValue;
-	logSample1.logValue = logSampleValue < 65536 ? Bit16u(logSampleValue) : 65535;
-	logSample1.sign = logSample1.sign == logSample2.sign ? LogSample::POSITIVE : LogSample::NEGATIVE;
-}
-
 Bit32u LA32WaveGenerator::getSampleStep() {
 	// sampleStep = EXP2F(pitch / 4096.0f + 4.0f)
 	Bit32u sampleStep = LA32Utilites::interpolateExp(~pitch & 4095);

--- a/mt32emu/src/LA32WaveGenerator.cpp
+++ b/mt32emu/src/LA32WaveGenerator.cpp
@@ -114,11 +114,11 @@ void LA32WaveGenerator::generateNextSquareWaveLogSample() {
 	switch (phase) {
 		case POSITIVE_RISING_SINE_SEGMENT:
 		case NEGATIVE_FALLING_SINE_SEGMENT:
-			logSampleValue = Tables::getInstance().logsin9[(squareWavePosition >> 9) & 511];
+			logSampleValue = Tables::logsin9[(squareWavePosition >> 9) & 511];
 			break;
 		case POSITIVE_FALLING_SINE_SEGMENT:
 		case NEGATIVE_RISING_SINE_SEGMENT:
-			logSampleValue = Tables::getInstance().logsin9[~(squareWavePosition >> 9) & 511];
+			logSampleValue = Tables::logsin9[~(squareWavePosition >> 9) & 511];
 			break;
 		case POSITIVE_LINEAR_SEGMENT:
 		case NEGATIVE_LINEAR_SEGMENT:
@@ -139,9 +139,9 @@ void LA32WaveGenerator::generateNextSquareWaveLogSample() {
 void LA32WaveGenerator::generateNextResonanceWaveLogSample() {
 	Bit32u logSampleValue;
 	if (resonancePhase == POSITIVE_FALLING_RESONANCE_SINE_SEGMENT || resonancePhase == NEGATIVE_RISING_RESONANCE_SINE_SEGMENT) {
-		logSampleValue = Tables::getInstance().logsin9[~(resonanceSinePosition >> 9) & 511];
+		logSampleValue = Tables::logsin9[~(resonanceSinePosition >> 9) & 511];
 	} else {
-		logSampleValue = Tables::getInstance().logsin9[(resonanceSinePosition >> 9) & 511];
+		logSampleValue = Tables::logsin9[(resonanceSinePosition >> 9) & 511];
 	}
 	logSampleValue <<= 2;
 	logSampleValue += amp >> 10;
@@ -154,10 +154,10 @@ void LA32WaveGenerator::generateNextResonanceWaveLogSample() {
 	// To ensure the output wave has no breaks, two different windows are applied to the beginning and the ending of the resonance sine segment
 	if (phase == POSITIVE_RISING_SINE_SEGMENT || phase == NEGATIVE_FALLING_SINE_SEGMENT) {
 		// The window is synchronous sine here
-		logSampleValue += Tables::getInstance().logsin9[(squareWavePosition >> 9) & 511] << 2;
+		logSampleValue += Tables::logsin9[(squareWavePosition >> 9) & 511] << 2;
 	} else if (phase == POSITIVE_FALLING_SINE_SEGMENT || phase == NEGATIVE_RISING_SINE_SEGMENT) {
 		// The window is synchronous square sine here
-		logSampleValue += Tables::getInstance().logsin9[~(squareWavePosition >> 9) & 511] << 3;
+		logSampleValue += Tables::logsin9[~(squareWavePosition >> 9) & 511] << 3;
 	}
 
 	if (cutoffVal < MIDDLE_CUTOFF_VALUE) {
@@ -166,7 +166,7 @@ void LA32WaveGenerator::generateNextResonanceWaveLogSample() {
 	} else if (cutoffVal < RESONANCE_DECAY_THRESHOLD_CUTOFF_VALUE) {
 		// For the cutoff values below this point, the amp of the resonance wave is sinusoidally decayed
 		Bit32u sineIx = (cutoffVal - MIDDLE_CUTOFF_VALUE) >> 13;
-		logSampleValue += Tables::getInstance().logsin9[sineIx] << 2;
+		logSampleValue += Tables::logsin9[sineIx] << 2;
 	}
 
 	// After all the amp decrements are added, it should be safe now to adjust the amp of the resonance wave to what we see on captures
@@ -179,9 +179,9 @@ void LA32WaveGenerator::generateNextResonanceWaveLogSample() {
 void LA32WaveGenerator::generateNextSawtoothCosineLogSample(LogSample &logSample) const {
 	Bit32u sawtoothCosinePosition = wavePosition + (1 << 18);
 	if ((sawtoothCosinePosition & (1 << 18)) > 0) {
-		logSample.logValue = Tables::getInstance().logsin9[~(sawtoothCosinePosition >> 9) & 511];
+		logSample.logValue = Tables::logsin9[~(sawtoothCosinePosition >> 9) & 511];
 	} else {
-		logSample.logValue = Tables::getInstance().logsin9[(sawtoothCosinePosition >> 9) & 511];
+		logSample.logValue = Tables::logsin9[(sawtoothCosinePosition >> 9) & 511];
 	}
 	logSample.logValue <<= 2;
 	logSample.sign = ((sawtoothCosinePosition & (1 << 19)) == 0) ? LogSample::POSITIVE : LogSample::NEGATIVE;
@@ -245,7 +245,7 @@ void LA32WaveGenerator::initSynth(const bool useSawtoothWaveform, const Bit8u us
 	resonanceSinePosition = 0;
 	resonancePhase = POSITIVE_RISING_RESONANCE_SINE_SEGMENT;
 	resonanceAmpSubtraction = (32 - resonance) << 10;
-	resAmpDecayFactor = Tables::getInstance().resAmpDecayFactor[resonance >> 2] << 2;
+	resAmpDecayFactor = Tables::resAmpDecayFactor[resonance >> 2] << 2;
 
 	pcmWaveAddress = NULL;
 	active = true;

--- a/mt32emu/src/LA32WaveGenerator.h
+++ b/mt32emu/src/LA32WaveGenerator.h
@@ -51,8 +51,8 @@ public:
   static inline __attribute__((always_inline)) Bit16u interpolateExp(const Bit16u fract) {
   	Bit16u expTabIndex = fract >> 3;
 	  Bit16u extraBits = ~fract & 7;
-	  Bit16u expTabEntry2 = 8191 - Tables::getInstance().exp9[expTabIndex];
-	  Bit16u expTabEntry1 = expTabIndex == 0 ? 8191 : (8191 - Tables::getInstance().exp9[expTabIndex - 1]);
+	  Bit16u expTabEntry2 = 8191 - Tables::exp9[expTabIndex];
+	  Bit16u expTabEntry1 = expTabIndex == 0 ? 8191 : (8191 - Tables::exp9[expTabIndex - 1]);
 	  return expTabEntry2 + (((expTabEntry1 - expTabEntry2) * extraBits) >> 3);
   }
   

--- a/mt32emu/src/Partial.cpp
+++ b/mt32emu/src/Partial.cpp
@@ -201,7 +201,7 @@ void Partial::startPartial(const Part *part, Poly *usePoly, const PatchCache *us
 	}
 
 	// CONFIRMED: pulseWidthVal calculation is based on information from Mok
-	pulseWidthVal = (poly->getVelocity() - 64) * (patchCache->srcPartial.wg.pulseWidthVeloSensitivity - 7) + Tables::getInstance().pulseWidth100To255[patchCache->srcPartial.wg.pulseWidth];
+	pulseWidthVal = (poly->getVelocity() - 64) * (patchCache->srcPartial.wg.pulseWidthVeloSensitivity - 7) + Tables::pulseWidth100To255[patchCache->srcPartial.wg.pulseWidth];
 	if (pulseWidthVal < 0) {
 		pulseWidthVal = 0;
 	} else if (pulseWidthVal > 255) {

--- a/mt32emu/src/TVF.cpp
+++ b/mt32emu/src/TVF.cpp
@@ -127,8 +127,6 @@ void TVF::reset(const TimbreParam::PartialParam *newPartialParam, unsigned int b
 	unsigned int key = partial->getPoly()->getKey();
 	unsigned int velocity = partial->getPoly()->getVelocity();
 
-	const Tables *tables = &Tables::getInstance();
-
 	baseCutoff = calcBaseCutoff(newPartialParam, basePitch, key, partial->getSynth()->controlROMFeatures->quirkTVFBaseCutoffLimit);
 #if MT32EMU_MONITOR_TVF >= 1
 	partial->getSynth()->printDebug("[+%lu] [Partial %d] TVF,base,%d", partial->debugGetSampleNum(), partial->debugGetPartialNum(), baseCutoff);
@@ -160,7 +158,7 @@ void TVF::reset(const TimbreParam::PartialParam *newPartialParam, unsigned int b
 	if (envTimeSetting <= 0) {
 		newIncrement = (0x80 | 127);
 	} else {
-		newIncrement = tables->envLogarithmicTime[newTarget] - envTimeSetting;
+		newIncrement = Tables::envLogarithmicTime[newTarget] - envTimeSetting;
 		if (newIncrement <= 0) {
 			newIncrement = 1;
 		}
@@ -189,7 +187,6 @@ void TVF::startDecay() {
 }
 
 void TVF::nextPhase() {
-	const Tables *tables = &Tables::getInstance();
 	int newPhase = phase + 1;
 
 	switch (newPhase) {
@@ -226,7 +223,7 @@ void TVF::nextPhase() {
 				newTarget--;
 			}
 		}
-		newIncrement = tables->envLogarithmicTime[targetDelta < 0 ? -targetDelta : targetDelta] - envTimeSetting;
+		newIncrement = Tables::envLogarithmicTime[targetDelta < 0 ? -targetDelta : targetDelta] - envTimeSetting;
 		if (newIncrement <= 0) {
 			newIncrement = 1;
 		}

--- a/mt32emu/src/Tables.h
+++ b/mt32emu/src/Tables.h
@@ -23,14 +23,7 @@
 
 namespace MT32Emu {
 
-class Tables {
-private:
-	Tables();
-	Tables(Tables &);
-	~Tables() {}
-
-public:
-	static const Tables &getInstance();
+namespace Tables {
 
 	// Constant LUTs
 
@@ -40,22 +33,22 @@ public:
 	// - PartialParam.tva.level
 	// - expression
 	// It's used to determine how much to subtract from the amp envelope's target value
-	Bit8u levelToAmpSubtraction[101];
+	extern Bit8u levelToAmpSubtraction[101];
 
 	// CONFIRMED: ...
-	Bit8u envLogarithmicTime[256];
+	extern Bit8u envLogarithmicTime[256];
 
 	// CONFIRMED: ...
-	Bit8u masterVolToAmpSubtraction[101];
+	extern Bit8u masterVolToAmpSubtraction[101];
 
 	// CONFIRMED:
-	Bit8u pulseWidth100To255[101];
+	extern Bit8u pulseWidth100To255[101];
 
-	Bit16u exp9[512];
-	Bit16u logsin9[512];
+	extern Bit16u exp9[512];
+	extern Bit16u logsin9[512];
 
-	const Bit8u *resAmpDecayFactor;
-}; // class Tables
+	extern const Bit8u *resAmpDecayFactor;
+} // class Tables
 
 } // namespace MT32Emu
 


### PR DESCRIPTION
So, i've got bored and decided to profile and optimize munt a bit, the first thing that I have come across was huge number of calls to `interpolateExp`, it was around ~10% of all samples, so I decided to inline it and it helped for non-LTO builds, but the inlined code was still really expensive, so i looked a little bit more and it was due to the `Tables` singleton, so I've got rid of it. And in the end I've managed to squeeze ~63% speedup

Benchmarks:
```
❯ hyperfine './mt32emu_smf2wav_org --force title.mid' './mt32emu_smf2wav_inline --force title.mid' './mt32emu_smf2wav_inline_tables --force title.mid'
Benchmark 1: ./mt32emu_smf2wav_org --force title.mid
  Time (mean ± σ):     22.944 s ±  0.170 s    [User: 22.798 s, System: 0.042 s]
  Range (min … max):   22.807 s … 23.398 s    10 runs
 
Benchmark 2: ./mt32emu_smf2wav_inline --force title.mid
  Time (mean ± σ):     21.395 s ±  0.226 s    [User: 21.251 s, System: 0.044 s]
  Range (min … max):   21.106 s … 21.729 s    10 runs
 
Benchmark 3: ./mt32emu_smf2wav_inline_tables --force title.mid
  Time (mean ± σ):     16.900 s ±  0.142 s    [User: 16.776 s, System: 0.041 s]
  Range (min … max):   16.671 s … 17.113 s    10 runs
 
Summary
  ./mt32emu_smf2wav_inline_tables --force title.mid ran
    1.27 ± 0.02 times faster than ./mt32emu_smf2wav_inline --force title.mid
    1.36 ± 0.02 times faster than ./mt32emu_smf2wav_org --force title.mid
 ```
 
 ```
 ❯ hyperfine './mt32emu_smf2wav_lto_org --force title.mid' './mt32emu_smf2wav_lto_inline --force title.mid' './mt32emu_smf2wav_lto_inline_tables --force title.mid'
Benchmark 1: ./mt32emu_smf2wav_lto_org --force title.mid
  Time (mean ± σ):     14.521 s ±  0.241 s    [User: 14.403 s, System: 0.043 s]
  Range (min … max):   14.257 s … 14.994 s    10 runs
 
Benchmark 2: ./mt32emu_smf2wav_lto_inline --force title.mid
  Time (mean ± σ):     14.471 s ±  0.157 s    [User: 14.360 s, System: 0.043 s]
  Range (min … max):   14.288 s … 14.757 s    10 runs
 
Benchmark 3: ./mt32emu_smf2wav_lto_inline_tables --force title.mid
  Time (mean ± σ):      8.901 s ±  0.159 s    [User: 8.821 s, System: 0.037 s]
  Range (min … max):    8.718 s …  9.279 s    10 runs
 
Summary
  ./mt32emu_smf2wav_lto_inline_tables --force title.mid ran
    1.63 ± 0.03 times faster than ./mt32emu_smf2wav_lto_inline --force title.mid
    1.63 ± 0.04 times faster than ./mt32emu_smf2wav_lto_org --force title.mid
```

Notes:
- CPU: i7-8550U
- title.md is the intro from The Secret of Monkey Island
- _org is the master commit
- _inline is only the LA32Utilities commit
- _inline_tables is with both commits

`__attribute__((always_inline))` and `__attribute__((constructor))` are not portable, so those needs better solution.